### PR TITLE
Add metric for first two rules of RSS

### DIFF
--- a/scenario_gym/metrics/__init__.py
+++ b/scenario_gym/metrics/__init__.py
@@ -1,5 +1,6 @@
 from scenario_gym.metrics.base import Metric, cache_mean, cache_metric
 from scenario_gym.metrics.collision import CollisionMetric
+from scenario_gym.metrics.rss.rss import RSS, RSSDistances
 from scenario_gym.metrics.trajectory import (
     EgoAvgSpeed,
     EgoDistanceTravelled,

--- a/scenario_gym/metrics/rss/__init__.py
+++ b/scenario_gym/metrics/rss/__init__.py
@@ -1,0 +1,2 @@
+from .callback import RSSDistances, RSSParameters
+from .rss import RSS, RSSBehaviourDetection

--- a/scenario_gym/metrics/rss/callback.py
+++ b/scenario_gym/metrics/rss/callback.py
@@ -1,0 +1,537 @@
+import warnings
+from typing import Dict, List, Tuple
+
+import numpy as np
+from numpy.linalg import norm
+from scenario_gym.callback import StateCallback
+from scenario_gym.metrics.rss.rss_utils import (
+    acceleration,
+    ahead,
+    coord_change,
+    direction,
+    inverse_direction,
+)
+from scenario_gym.state import Entity, State
+from shapely.geometry import LineString, Polygon
+
+
+class RSSParameters:
+    # Parameters to be adjusted.
+    RESPONSE_TIME = 0.6  # SECONDS
+    MIN_LONG_ACCEL = 1.2 * 9.81  # METRES PER SECONDS SQUARED
+    MAX_LONG_ACCEL = 1.2 * 9.81  # METRES PER SECONDS SQUARED
+    MIN_SAFE_CLEARANCE = 0.1  # METRES
+    SHADOW_LENGTH = 100  # METRES
+    VISIBLE_RADIUS = 50  # METRES
+    LANE_ANGLE_VARIATION = 0.985  # COS(ANGLE)
+    TIME_HORIZON = 3  # SECONDS
+
+
+class RSSDistances(StateCallback):
+    """
+    Determines if the ego-entity distance has become unsafe
+
+    This is the per-timestep pre-computation for the first two rules of the
+    RSS metric. Raw values are calculated and attached to the global state or
+    entity attributes. Unsafe distances are flagged per entity in the global
+    state, which the metric uses to return a boolean value per rule.
+    """
+
+    def reset(self, state: State):
+        """resets callback and declares variables"""
+        super().reset(state)
+        assert len(state.scenario.entities) > 0, "Scenario contains zero entities."
+        self.ego = state.scenario.entities[0]
+        self.entities = state.scenario.entities
+        # Initialise default callback parameters
+        state.ego_params = {}
+        state.entity_params = [{} for entity in self.entities[1:]]
+        state.safe_distances = [[0.0, 0.0] for entity in self.entities[1:]]
+        state.intersect = [["safe"] for entity in self.entities[1:]]
+        for entity in self.entities:
+            entity.safe_ratios = [float("inf"), float("inf")]
+
+    def __call__(self, state: State):
+        """
+        label each entity to specify if its distances to the ego are unsafe.
+
+        Collates current timestep data for each entity, and determines the
+        safety of the ego with respect to its longitudinal and lateral distance
+        to each entity.
+
+        --  Creates entity parameter dictionary from current pose and bounding box
+        --  Calculates safe lateral and longitudinal distance to each entity
+        --  Calculates safe distance ratios for rss-based colour-coding
+        --  Determines, for each entity, if its position intersects the
+            corresponding ego safe buffer, and if so, which direction should be
+            flagged as unsafe
+        """
+        if state._t == 0.0:
+            # Require at least two poses to calculate velocity
+            return
+
+        # Establish Ego parameters
+        ego = self.ego
+        entities = self.entities
+        try:
+            ego_heading = direction(ego.pose[3])
+            ego_inverse_heading = inverse_direction(list(ego_heading))
+            entity_params = []
+            ego_position = ego.pose[0:2]
+        except IndexError:
+            # Ego has invalid pose
+            warnings.warn(
+                "RSSDistances _step: Error in handling of ego at time {0}. Invalid pose: {1}. RSSDistances callback skips this timestep.".format(
+                    state._t, entity.pose
+                )
+            )
+            return
+        # Create a dictionary for each entity of form:
+        # {position, heading, velocity, acceleration, box_points, length, width}
+        # With directional and positional parameters defined with respect to ego
+        # frame.
+        for entity in entities:
+            entity_dictionary = self.get_entity_parameters(
+                entity, ego_heading, ego_inverse_heading, ego_position, state.dt
+            )
+            if entity_dictionary is None:
+                warnings.warn(
+                    "RSSDistances _step: Error in handling of entity {0} at time {1}. Invalid pose: {2}. RSS metric skips entity at this timestep.".format(
+                        entity, state._t, entity.pose
+                    )
+                )
+                continue
+            else:
+                entity_params.append(entity_dictionary)
+        if len(entity_params) == 0:
+            warnings.warn(
+                "Zero entity parameters generated at timestep: {0}".format(state.t)
+            )
+            return
+
+        # Calculate safe distances between ego and all other entities
+        ego_params = entity_params.pop(0)
+        safe_distances = []
+        for entity in entity_params:
+            safe_long = abs(self.safe_longitudinal_distance(ego_params, entity))
+            safe_lat = abs(self.safe_lateral_distance(ego_params, entity))
+            safe_distances.append([safe_lat, safe_long])
+
+        # Assign evaluated parameters to the state
+        assert len(entity_params) == len(safe_distances)
+        state.ego_params = ego_params
+        state.entity_params = entity_params
+        state.safe_distances = safe_distances
+
+        # Check for each entity if there is an intersection of safe distance buffer
+        # and assign safe distance ratios to entity as an attribute
+        for i in range(len(entity_params)):
+            self.safe_ratios(
+                entities[i + 1], ego_params, entity_params[i], safe_distances[i]
+            )
+            state.intersect[i].append(
+                self.unsafe_distance(
+                    ego_params,
+                    entity_params[i],
+                    state.intersect[i],
+                    safe_distances[i],
+                )
+            )
+            if state.intersect[i] is None:
+                # Entity trimmed poses results in IndexError, go to next entity
+                warnings.warn(
+                    "safe_longitudinal: IndexError in handling of entity number: {0} at timestep: {1} seconds. Continue to next entity.".format(
+                        i, state._t
+                    )
+                )
+
+    @staticmethod
+    def safe_ratios(
+        entity: Entity, ego: Dict, haz: Dict, safe_distances: List[float]
+    ) -> None:
+        """
+        Attaches safe_distance ratios to entity
+
+        safe ratio defined as actual_distance / safe_distance -> larger ratio safer
+        """
+        try:
+            safe_lat = safe_distances[0] + 0.5 * abs(
+                np.dot(
+                    [haz["width"], haz["length"]], inverse_direction(haz["heading"])
+                )
+            )
+            safe_long = safe_distances[1] + 0.5 * abs(
+                np.dot([haz["width"], haz["length"]], haz["heading"])
+            )
+        except IndexError:
+            # safe_distances not calculated
+            warnings.warn(
+                "RSSDistances safe_ratios: Safe distances not calculated. Default safe distances as ego dimensions"
+            )
+            safe_lat = 0.5 * ego["width"]
+            safe_long = 0.5 * ego["length"]
+
+        actual_lat = max(
+            1e-6,
+            abs(haz["position"][0])
+            - 0.5 * ego["width"]
+            - 0.5
+            * abs(
+                np.dot(
+                    [haz["width"], haz["length"]], inverse_direction(haz["heading"])
+                )
+            ),
+        )
+        actual_long = max(
+            1e-6,
+            abs(haz["position"][1])
+            - 0.5 * ego["length"]
+            - 0.5 * abs(np.dot([haz["width"], haz["length"]], haz["heading"])),
+        )
+        safe_ratios = [abs(actual_lat / safe_lat), abs(actual_long / safe_long)]
+        entity.safe_ratios = safe_ratios
+
+    @staticmethod
+    def unsafe_distance(
+        ego: Dict, haz: Dict, intersect: List[str], safe_distances: List[float]
+    ) -> str:
+        """
+        Determines if longitudinal or lateral distance is hazardous to ego
+
+        This method is called per timestep per entity, and returns a flag to be
+        attached to the global state.
+
+        --  Laterally unsafe if both longitudinal and lateral distances are unsafe,
+            and the lateral distance became unsafe after the longitudinal distance.
+        --  Longitudinally unsafe if both longitudinal and lateral distances are
+            unsafe, and the longitudinal distance became unsafe after the lateral
+            distance.
+        """
+
+        if "unsafe_lateral" in intersect or "unsafe_longitudinal" in intersect:
+            # Already found
+            intersect.append("found")
+            return intersect
+
+        buffer, lengths, widths = RSSDistances.generate_buffer(ego, safe_distances)
+
+        assert (
+            buffer.area > 0.0
+        ), "safe_longitudinal: buffer constructed as a 'Z' rather than as a '[]'"
+
+        hazard_area = Polygon(haz["box_points"])
+        if hazard_area.intersects(buffer):
+            # Find which direction became unsafe last: this is the unsafe direction
+            for j in range(len(intersect), 0, -1):
+                try:
+                    if intersect[j - 1] == "lateral":
+                        # longitudinal intersection last: longitudinally unsafe
+                        return "unsafe_longitudinal"
+                    elif intersect[j - 1] == "longitudinal":
+                        # lateral intersection last: laterally unsafe
+                        return "unsafe_lateral"
+                except IndexError:
+                    break
+                # default, if no previous intersection found.
+                if j == 1:
+                    ego_dim = [ego["width"], ego["length"]]
+                    if abs(
+                        abs(haz["position"][0])
+                        - abs(np.dot(haz["position"], ego_dim))
+                    ) / safe_distances[0] > abs(
+                        abs(
+                            haz["position"][1]
+                            - np.dot(
+                                haz["position"],
+                                inverse_direction(ego_dim),
+                            )
+                        )
+                        / safe_distances[1]
+                    ):
+                        return "unsafe_longitudinal"
+                    else:
+                        return "unsafe_lateral"
+        # This entity does not intersect buffer, so check if a dimension intersects
+        return RSSDistances.write_intersections(lengths, widths, haz)
+
+    @staticmethod
+    def safe_longitudinal_distance(ego: Dict, haz: Dict) -> float:
+        """
+        Determines if the longitudinal distance is safe
+        """
+        MAX_LONG_ACCEL = RSSParameters.MAX_LONG_ACCEL
+        MIN_LONG_ACCEL = RSSParameters.MIN_LONG_ACCEL
+        MIN_SAFE_CLEARANCE = RSSParameters.MIN_SAFE_CLEARANCE
+        RESPONSE_TIME = RSSParameters.RESPONSE_TIME
+        ego_direction = ego["heading"]
+        hazard_direction = haz["heading"]
+        ego_velocity = ego["velocity"]
+        hazard_velocity = haz["velocity"]
+        max_long_accel = abs(
+            MAX_LONG_ACCEL * np.dot(ego_direction, hazard_direction)
+        )
+        if np.dot(ego_direction, hazard_direction) > 0:
+            # Moving in the same direction (longitudinal component)
+            if ahead(ego, haz):
+                vf = norm(ego_velocity)
+                vr = np.dot(hazard_velocity, ego_direction)
+            else:
+                vf = np.dot(hazard_velocity, ego_direction)
+                vr = norm(ego_velocity)
+            if vr == 0.0:
+                # If rear car is stationary, safe
+                return MIN_SAFE_CLEARANCE + 0.5 * ego["length"]
+            d0 = RSSDistances.long_dist_same_direction(
+                vf, vr, max_long_accel, RESPONSE_TIME, MIN_LONG_ACCEL
+            )
+        else:
+            # Moving in the opposite direction (longitudinal component)
+            v1 = abs(np.dot(ego_velocity, ego_direction))
+            v2 = -abs(np.dot(hazard_velocity, ego_direction))
+            # Makes no distinction between driver in correct or incorrect lane,
+            # where RSS is specific
+            if np.sign(haz["position"][1]) == np.sign(haz["velocity"][1]):
+                return MIN_SAFE_CLEARANCE + 0.5 * ego["length"]
+            d0 = RSSDistances.long_dist_opp_direction(
+                v1, v2, max_long_accel, RESPONSE_TIME, MIN_LONG_ACCEL
+            )
+        return d0 + MIN_SAFE_CLEARANCE + 0.5 * ego["length"]
+
+    @staticmethod
+    def safe_lateral_distance(ego: Dict, haz: Dict) -> float:
+        """
+        Determines if the lateral distance is safe
+        """
+        MAX_LONG_ACCEL = RSSParameters.MAX_LONG_ACCEL
+        MIN_LONG_ACCEL = RSSParameters.MIN_LONG_ACCEL
+        MIN_SAFE_CLEARANCE = RSSParameters.MIN_SAFE_CLEARANCE
+        RESPONSE_TIME = RSSParameters.RESPONSE_TIME
+        haz_position = np.array(haz["position"])
+        # Resolve into velocity components para and perp to hazard's velocity
+        # Velocity takes form [longitudinal, lateral]
+        # Define lateral velocity as ego's velocity component perp to hazard
+        v = haz["velocity"][0]  # component perpendicular to ego's heading
+        max_lat_accel = MAX_LONG_ACCEL * abs(
+            np.dot(inverse_direction(ego["heading"]), haz["heading"])
+        )
+        min_lat_accel = MIN_LONG_ACCEL * abs(
+            np.dot(inverse_direction(ego["heading"]), haz["heading"])
+        )
+        if np.sign(-haz_position[0]) == np.sign(v):
+            # lateral convergence
+            v = abs(v)
+            if v == 0.0:
+                # Driving parallel, safe for sufficient constant distance.
+                return MIN_SAFE_CLEARANCE + 0.5 * ego["width"]
+            d0 = RSSDistances.lat_dist(
+                v, max_lat_accel, min_lat_accel, RESPONSE_TIME
+            )
+        else:
+            # lateral divergence: safe distance is the avg of car widths
+            # plus min_safe_distance
+            d0 = 0
+        return d0 + MIN_SAFE_CLEARANCE + 0.5 * ego["width"]
+
+    @staticmethod
+    def write_intersections(
+        buffer_lengths: List[LineString],
+        buffer_widths: List[LineString],
+        haz_dict: Dict,
+    ) -> str:
+        """
+        For ego and another entity, checks if the entity has a smaller distance in
+        the longitudinal or lateral direction than the corresponding safe distance,
+        and appends this to the recorded list.
+        """
+        haz_area = Polygon(haz_dict["box_points"])
+        lat_inter = False
+        long_inter = False
+
+        if haz_area.intersects(buffer_lengths[0]) or haz_area.intersects(
+            buffer_lengths[1]
+        ):
+            lat_inter = True
+        if haz_area.intersects(buffer_widths[0]) or haz_area.intersects(
+            buffer_widths[1]
+        ):
+            long_inter = True
+
+        if lat_inter and long_inter:
+            new_record = "both"
+        elif lat_inter:
+            new_record = "lateral"
+        elif long_inter:
+            new_record = "longitudinal"
+        else:
+            new_record = "safe"
+        return new_record
+
+    @staticmethod
+    def get_entity_parameters(
+        entity: Entity,
+        ego_heading: List[float],
+        ego_inverse_heading: List[float],
+        ego_position: List[float],
+        dt: float,
+    ) -> Dict:
+        """Calculates entity parameters and returns these as a dictionary."""
+        entity_pose = entity.pose
+        if len(entity_pose) != 6:
+            warnings.warn(
+                "Entity pose should have six elements, [x, y, z, h, r, p]. Received {0} elements.".format(
+                    len(entity_pose)
+                )
+            )
+            return
+        ego_position = np.array(ego_position)
+        entity_heading = direction(entity_pose[3])
+        entity_acceleration = acceleration(entity.recorded_poses, dt)
+        # All vectors take form [lateral, longitudinal] / [x, y]
+        entity_dictionary = {
+            "position": coord_change(entity_pose[0:2], ego_heading, ego_position),
+            "heading": [
+                np.dot(entity_heading, ego_inverse_heading),
+                np.dot(entity_heading, ego_heading),
+            ],
+            "velocity": [
+                np.dot(entity.velocity[:2], ego_inverse_heading),
+                np.dot(entity.velocity[:2], ego_heading),
+            ],
+            "accel": [
+                np.dot(
+                    entity_acceleration,
+                    ego_inverse_heading,
+                ),
+                np.dot(entity_acceleration, ego_heading),
+            ],
+            "box_points": [
+                coord_change(point, ego_heading, ego_position)
+                for point in entity.get_bounding_box_points()
+            ],
+            "length": entity.catalog_entry.bounding_box.length,
+            "width": entity.catalog_entry.bounding_box.width,
+        }
+        return entity_dictionary
+
+    @staticmethod
+    def generate_buffer(
+        ego: Dict, safe_distances: List
+    ) -> Tuple[Polygon, List[LineString]]:
+        """
+        Generate ego safe buffer corresponding to entity's safe distances
+
+        Generates a rectangular buffer around the entity with length and width
+        corresponding to safe longitudinal and lateral distances with respect to
+        the other entity. Returns the Polygon of this buffer along with a list of
+        linestrings of its lengths and widths.
+        """
+        assert ego["position"] == [0.0, 0.0], ego["position"]
+        try:
+            safe_longitudinal_distance = safe_distances[1]
+            safe_lateral_distance = safe_distances[0]
+        except IndexError:
+            # Safe distances not calculated
+            warnings.warn(
+                "RSSDistances generate_buffer: Safe distances not calculated: Buffer cannot be instantiated. Default safe distances as 3 metres lateral, 5 metres safe longitudinal"
+            )
+            safe_longitudinal_distance = 5
+            safe_lateral_distance = 3
+
+        buffer_vector = [
+            np.array([0, safe_longitudinal_distance]),
+            np.array([safe_lateral_distance, 0]),
+        ]
+        buffer = [
+            np.array(buffer_vector[0] + buffer_vector[1]),
+            np.array(buffer_vector[0] - buffer_vector[1]),
+            np.array(-buffer_vector[0] - buffer_vector[1]),
+            np.array(-buffer_vector[0] + buffer_vector[1]),
+        ]
+        widths = [
+            LineString(
+                [
+                    [100 * buffer[0][0], buffer[0][1]],
+                    [100 * buffer[1][0], buffer[1][1]],
+                ]
+            ),
+            LineString(
+                [
+                    [100 * buffer[2][0], buffer[2][1]],
+                    [100 * buffer[3][0], buffer[3][1]],
+                ]
+            ),
+        ]
+        lengths = [
+            LineString(
+                [
+                    [buffer[0][0], 100 * buffer[0][1]],
+                    [buffer[2][0], 100 * buffer[2][1]],
+                ]
+            ),
+            LineString(
+                [
+                    [buffer[1][0], 100 * buffer[1][1]],
+                    [buffer[3][0], 100 * buffer[3][1]],
+                ]
+            ),
+        ]
+        return Polygon(buffer), lengths, widths
+
+    @staticmethod
+    def long_dist_same_direction(
+        vf: float,
+        vr: float,
+        max_long_accel: float,
+        RESPONSE_TIME: float,
+        MIN_LONG_ACCEL: float,
+    ) -> float:
+        """
+        Returns the minimum safe longitudinal distance for same directions.
+        """
+        return max(
+            0,
+            vr * RESPONSE_TIME
+            + min(
+                vf**2 / (2 * max_long_accel),
+                0.5 * max_long_accel * RESPONSE_TIME**2,
+            )
+            + (vr + RESPONSE_TIME * max_long_accel) ** 2 / (2 * MIN_LONG_ACCEL)
+            - vf**2 / (2 * max_long_accel),
+        )
+
+    @staticmethod
+    def long_dist_opp_direction(
+        v1: float,
+        v2: float,
+        max_long_accel: float,
+        RESPONSE_TIME: float,
+        MIN_LONG_ACCEL: float,
+    ) -> float:
+        """
+        Returns the minimum safe longitudinal distance for opposing directions.
+        """
+        return max(
+            0,
+            (
+                (2 * v1 + RESPONSE_TIME * max_long_accel) * RESPONSE_TIME / 2
+                + (v1 + RESPONSE_TIME * max_long_accel) ** 2 / (2 * MIN_LONG_ACCEL)
+                + (2 * abs(v2) + RESPONSE_TIME * max_long_accel) * RESPONSE_TIME / 2
+                + (abs(v2) + RESPONSE_TIME * max_long_accel) ** 2
+                / (2 * MIN_LONG_ACCEL)
+            ),
+        )
+
+    @staticmethod
+    def lat_dist(
+        v: float, max_lat_accel: float, min_lat_accel: float, RESPONSE_TIME: float
+    ):
+        """
+        Returns the minimum safe lateral distance between the entity and ego.
+        """
+        return max(
+            0,
+            0.5 * RESPONSE_TIME * (2 * v + RESPONSE_TIME * max_lat_accel)
+            + (v + RESPONSE_TIME * max_lat_accel) ** 2 / (2 * min_lat_accel)
+            - 0.5 * RESPONSE_TIME**2 * max_lat_accel
+            - (RESPONSE_TIME * max_lat_accel) ** 2 / (2 * min_lat_accel),
+        )

--- a/scenario_gym/metrics/rss/rss.py
+++ b/scenario_gym/metrics/rss/rss.py
@@ -22,9 +22,7 @@ from .callback import RSSDistances
 
 
 class Rules(Enum):
-    """
-    Enumerates the five rules
-    """
+    """Enumerate the five rules."""
 
     safe_longitudinal = 0
     safe_lateral = 1
@@ -32,7 +30,7 @@ class Rules(Enum):
 
 class RSSBehaviourDetection:
     """
-    Finds behaviours corresponding to the five RSS rules
+    Find behaviours corresponding to the five RSS rules.
 
     Instantiates class based on current timestep state and
     parameters. Calls each of the behaviour methods, one per
@@ -64,9 +62,7 @@ class RSSBehaviourDetection:
         self.collisions = collisions
 
     def __call__(self):
-        """
-        call behaviour methods for current timestep
-        """
+        """Call behaviour methods for current timestep."""
         outcomes = {}
         for rule in Rules:
             outcome = getattr(self, rule.name)
@@ -77,7 +73,7 @@ class RSSBehaviourDetection:
     # Behaviour functions
     def safe_longitudinal(self) -> bool:
         """
-        Rule 1: ego at a safe longitudinal distance
+        Rule 1: ego at a safe longitudinal distance.
 
         Returns True if longitudinal distance is less than the minimum
         safe distance when the lateral distance is also unsafe, with the safe
@@ -94,7 +90,7 @@ class RSSBehaviourDetection:
 
     def safe_lateral(self) -> bool:
         """
-        Rule 2: ego at a safe lateral distance
+        Rule 2: ego at a safe lateral distance.
 
         Returns True if lateral distance is less than the minimum
         safe distance when the longitudinal distance is also unsafe, with the
@@ -112,7 +108,7 @@ class RSSBehaviourDetection:
 
 class RSS(Metric):
     """
-    Determines if the ego follow the 5 rules of RSS
+    Determine if the ego follow the 5 rules of RSS.
 
     _reset() resets state with each rule set to True by default
 
@@ -130,7 +126,7 @@ class RSS(Metric):
     required_callbacks = [RSSDistances]
 
     def _reset(self, state: State) -> None:
-        """Resets behaviour"""
+        """Reset behaviour."""
         self.behaviour = None
         self.ego = state.scenario.entities[0]
         for entity in state.scenario.entities:
@@ -139,8 +135,7 @@ class RSS(Metric):
         self.metrics_ = {rule.name: True for rule in Rules}
 
     def _step(self, state: State) -> None:
-        """Update the metric to find behaviour at the point of interest"""
-
+        """Update the metric to find behaviour at the point of interest."""
         if state._t == 0.0:
             # Require at least two poses to calculate velocity
             return
@@ -173,5 +168,5 @@ class RSS(Metric):
             )
 
     def get_state(self) -> Dict[str, bool]:
-        """Returns state"""
+        """Return state."""
         return self.metrics_

--- a/scenario_gym/metrics/rss/rss.py
+++ b/scenario_gym/metrics/rss/rss.py
@@ -1,0 +1,177 @@
+# Implement Mobileye's 5 rules of Responsibility-Sensitive Safety (RSS) as
+# a metric compatible with driving gym.
+# The five rules are
+#   1)  Safe longitudinal distance to vehicles in the same lane
+#   2)  Safe lateral distance to vehicles when merging lane
+#   3)  Forfeiting right of way at junctions when another road user undermines
+#       correct priority
+#   4)  Additional caution in areas of occlusion
+#   5)  Avoid a collision by any means without jeopardising safety of other
+#       road users
+
+import string
+import warnings
+from enum import Enum
+from typing import Dict, List
+
+from scenario_gym.metrics import Metric
+from scenario_gym.road_network import road_network
+from scenario_gym.state import State
+
+from .callback import RSSDistances
+
+
+class Rules(Enum):
+    """
+    Enumerates the five rules
+    """
+
+    safe_longitudinal = 0
+    safe_lateral = 1
+
+
+class RSSBehaviourDetection:
+    """
+    Finds behaviours corresponding to the five RSS rules
+
+    Instantiates class based on current timestep state and
+    parameters. Calls each of the behaviour methods, one per
+    RSS rule. These methods are lightweight, with most computation
+    performed in the rss callback. Each method returns a bool
+    value corresponding to whether or not the rule is obeyed at each
+    timestep -- if the rule has not already been failed.
+    """
+
+    # Initialise and call the behaviour functions
+    def __init__(
+        self,
+        metrics: Dict,
+        ego: Dict,
+        entities: List[Dict],
+        safe_distances: List[List[float]],
+        road_network: road_network,
+        dt: float,
+        intersect: string,
+        collisions,
+    ):
+        self.metrics = metrics
+        self.ego = ego
+        self.entities = entities
+        self.safe_distances = safe_distances
+        self.road_network = road_network
+        self.dt = dt
+        self.intersect = intersect
+        self.collisions = collisions
+
+    def __call__(self):
+        """
+        call behaviour methods for current timestep
+        """
+        outcomes = {}
+        for rule in Rules:
+            outcome = getattr(self, rule.name)
+            outcomes[rule.name] = outcome()
+        intersect = self.intersect
+        return outcomes, intersect
+
+    # Behaviour functions
+    def safe_longitudinal(self) -> bool:
+        """
+        Rule 1: ego at a safe longitudinal distance
+
+        Returns True if longitudinal distance is less than the minimum
+        safe distance when the lateral distance is also unsafe, with the safe
+        longitudinal distance crossed last.
+        """
+        if not self.metrics["safe_longitudinal"]:
+            # Already found
+            return True
+        # Check if any entities have been flagged as being unsafe longitudinally.
+        for entity_record in self.intersect:
+            if "unsafe_longitudinal" in entity_record:
+                return False
+        return True
+
+    def safe_lateral(self) -> bool:
+        """
+        Rule 2: ego at a safe lateral distance
+
+        Returns True if lateral distance is less than the minimum
+        safe distance when the longitudinal distance is also unsafe, with the
+        safe lateral distance crossed last.
+        """
+        if not self.metrics["safe_lateral"]:
+            # Already found
+            return True
+        # Check if any entities have been flagged as being unsafe laterally.
+        for entity_record in self.intersect:
+            if "unsafe_lateral" in entity_record:
+                return False
+        return True
+
+
+class RSS(Metric):
+    """
+    Determines if the ego follow the 5 rules of RSS
+
+    _reset() resets state with each rule set to True by default
+
+    _step() calls RSSBehaviourDetection to check if the ego is
+    obeying the RSS rules at the current timestep. rss/callback
+    is responsible for bulk of the computation and is called prior
+    to the metric call at each timestep.
+
+    get_state() returns dictionary of bools, one per rule
+    --  True: the rule is obeyed at every timestep
+    --  False: the rule is disobeyed in at least one timestep
+        (may not be fault of ego - separate metric for blame)
+    """
+
+    required_callbacks = [RSSDistances]
+
+    def _reset(self, state: State) -> None:
+        """Resets behaviour"""
+        self.behaviour = None
+        self.ego = state.scenario.entities[0]
+        for entity in state.scenario.entities:
+            if not entity.record_trajectory:
+                entity.recorded_trajectory = True
+        self.metrics_ = {rule.name: True for rule in Rules}
+
+    def _step(self, state: State) -> None:
+        """Update the metric to find behaviour at the point of interest"""
+
+        if state._t == 0.0:
+            # Require at least two poses to calculate velocity
+            return
+
+        ego, entities, safe_distances, intersect = (
+            state.ego_params,
+            state.entity_params,
+            state.safe_distances,
+            state.intersect,
+        )
+        rules = RSSBehaviourDetection(
+            metrics=self.metrics_,
+            ego=ego,
+            entities=entities,
+            safe_distances=safe_distances,
+            road_network=state.scenario.road_network,
+            dt=state.dt,
+            intersect=state.intersect,
+            collisions=state.collisions,
+        )
+        try:
+            outcomes, intersect = rules()
+            self.intersect = intersect
+            for rule, outcome in outcomes.items():
+                if outcome is False:
+                    self.metrics_[rule] = outcome
+        except IndexError:
+            warnings.warn(
+                "RSSBehaviourDetection: IndexError caught at time " + str(state._t)
+            )
+
+    def get_state(self) -> Dict[str, bool]:
+        """Returns state"""
+        return self.metrics_

--- a/scenario_gym/metrics/rss/rss_utils.py
+++ b/scenario_gym/metrics/rss/rss_utils.py
@@ -1,0 +1,106 @@
+import warnings
+from typing import Dict, Iterable, List
+
+import numpy as np
+from numpy.linalg import norm
+
+
+def inverse_direction(vector: Iterable, normalised: bool = True) -> Iterable:
+    """
+    returns the inverse of a 2D vector, Iterable -> Iterable
+
+    Uses clockwise-rotating sign convention: (x, y) --> (y, -x)
+
+    Optional parameter normalised (default True):
+    --  True: returns vector of unit length
+    --  False: returns vector of same length as the input vector
+    """
+    assert len(vector) == 0, "Invalid vector dimension: {0}".format(len(vector))
+    if normalised:
+        return [vector[1], -vector[0]] / norm([vector[1], vector[0]])
+    else:
+        return [vector[1], -vector[0]]
+
+
+def coord_change(
+    vector: List[float], direction: List[float], centre=[0, 0]
+) -> List[float]:
+    """
+    Changes vector coordinates to new frame of reference.
+
+    Uses Galilean transformation to change the components of <vector> to a new
+    coordinate system defined by an origin at <centre> and with components parallel
+    and perpendicular to <direction>
+
+    Optional argument centre (default [0, 0])
+    """
+    assert len(vector) == 2, (
+        "coord_change is implemented to work in 2D. Passed vector dimension: "
+        + str(len(vector))
+    )
+    vector = np.array(vector)
+    centre = np.array(centre)
+    inv_dir = inverse_direction(direction)
+    return [np.dot((vector - centre), inv_dir), np.dot(vector - centre, direction)]
+
+
+def acceleration(
+    entity_poses: List[List[float]],
+    dt: float,
+    parallel_velocity: bool = False,
+    i: int = 0,
+) -> List[float]:
+    """
+    Finds entity acceleration from three consecutive poses
+
+    Optional argument parallel_velocity (default False):
+    --  True: acceleration is resolved in coords para and perp to velocity
+    --  False: acceleration remains in pose coords
+    """
+    try:
+        entity_pose_2 = entity_poses[i + 2][1:3]
+        entity_pose_1 = entity_poses[i + 1][1:3]
+        entity_pose_0 = entity_poses[i][1:3]
+    except IndexError:
+        warnings.warn(
+            "Insufficient number of poses to calculate acceleration. Required: >= 3. Received: {0}. Default with zero acceleration".format(
+                len(entity_poses)
+            )
+        )
+        return [0.0, 0.0]
+    velocity_1 = (entity_pose_1 - entity_pose_2) / dt
+    velocity_0 = (entity_pose_0 - entity_pose_1) / dt
+    accel = np.array((velocity_0 - velocity_1) / dt)
+    if not parallel_velocity:
+        return accel
+    # Resolve acceleration vector into [para to velocity, perp to velocity]
+    return [
+        np.dot(velocity_1, accel) / norm(velocity_1),
+        np.dot([-velocity_1[1], velocity_1[0]] / norm(velocity_1), accel),
+    ]
+
+
+def ahead(ego: Dict, haz: Dict) -> bool:
+    """
+    Determines if ego is ahead of hazard
+
+    Takes two entities (ego and hazard) and returns True if the ego is ahead
+    of the hazard when using ego's preferential frame of reference such that:
+    --  ego is at position [0.0, 0.0]
+    --  ego direction is [0, 1] ...
+    --  ... requiring ego velocity to be parallel to y axis
+    """
+    ego_position = ego["position"][1]
+    haz_position = haz["position"][1]
+    return ego_position > haz_position
+
+
+def direction(heading: float) -> list:
+    """
+    Turns heading into normalised direction vector.
+
+    angle (rad) --> [x component, y component]
+    Where 0 rad corresponds to positive x unit vector, and a positively
+    increasing angle moves in counter-clockwise direction.
+    """
+    return [np.cos(heading), np.sin(heading)]

--- a/scenario_gym/metrics/rss/rss_utils.py
+++ b/scenario_gym/metrics/rss/rss_utils.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Dict, Iterable, List
 
 import numpy as np

--- a/scenario_gym/metrics/rss/rss_utils.py
+++ b/scenario_gym/metrics/rss/rss_utils.py
@@ -7,7 +7,7 @@ from numpy.linalg import norm
 
 def inverse_direction(vector: Iterable, normalised: bool = True) -> Iterable:
     """
-    returns the inverse of a 2D vector, Iterable -> Iterable
+    Return the inverse of a 2D vector, Iterable -> Iterable.
 
     Uses clockwise-rotating sign convention: (x, y) --> (y, -x)
 
@@ -26,7 +26,7 @@ def coord_change(
     vector: List[float], direction: List[float], centre=[0, 0]
 ) -> List[float]:
     """
-    Changes vector coordinates to new frame of reference.
+    Change vector coordinates to new frame of reference.
 
     Uses Galilean transformation to change the components of <vector> to a new
     coordinate system defined by an origin at <centre> and with components parallel
@@ -51,7 +51,7 @@ def acceleration(
     i: int = 0,
 ) -> List[float]:
     """
-    Finds entity acceleration from three consecutive poses
+    Find entity acceleration from three consecutive poses.
 
     Optional argument parallel_velocity (default False):
     --  True: acceleration is resolved in coords para and perp to velocity
@@ -63,7 +63,8 @@ def acceleration(
         entity_pose_0 = entity_poses[i][1:3]
     except IndexError:
         warnings.warn(
-            "Insufficient number of poses to calculate acceleration. Required: >= 3. Received: {0}. Default with zero acceleration".format(
+            "Insufficient number of poses to calculate acceleration. Required: >= "
+            "3. Received: {0}. Default with zero acceleration".format(
                 len(entity_poses)
             )
         )
@@ -82,7 +83,7 @@ def acceleration(
 
 def ahead(ego: Dict, haz: Dict) -> bool:
     """
-    Determines if ego is ahead of hazard
+    Determine if ego is ahead of hazard.
 
     Takes two entities (ego and hazard) and returns True if the ego is ahead
     of the hazard when using ego's preferential frame of reference such that:
@@ -97,7 +98,7 @@ def ahead(ego: Dict, haz: Dict) -> bool:
 
 def direction(heading: float) -> list:
     """
-    Turns heading into normalised direction vector.
+    Turn heading into normalised direction vector.
 
     angle (rad) --> [x component, y component]
     Where 0 rad corresponds to positive x unit vector, and a positively

--- a/scenario_gym/metrics/rss/rss_utils.py
+++ b/scenario_gym/metrics/rss/rss_utils.py
@@ -15,7 +15,7 @@ def inverse_direction(vector: Iterable, normalised: bool = True) -> Iterable:
     --  True: returns vector of unit length
     --  False: returns vector of same length as the input vector
     """
-    assert len(vector) == 0, "Invalid vector dimension: {0}".format(len(vector))
+    assert len(vector) == 2, "Invalid vector dimension: {0}".format(len(vector))
     if normalised:
         return [vector[1], -vector[0]] / norm([vector[1], vector[0]])
     else:
@@ -62,12 +62,7 @@ def acceleration(
         entity_pose_1 = entity_poses[i + 1][1:3]
         entity_pose_0 = entity_poses[i][1:3]
     except IndexError:
-        warnings.warn(
-            "Insufficient number of poses to calculate acceleration. Required: >= "
-            "3. Received: {0}. Default with zero acceleration".format(
-                len(entity_poses)
-            )
-        )
+        # If too few poses received, default with accel = [0, 0]
         return [0.0, 0.0]
     velocity_1 = (entity_pose_1 - entity_pose_2) / dt
     velocity_0 = (entity_pose_0 - entity_pose_1) / dt

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,0 +1,22 @@
+from scenario_gym.scenario_gym import ScenarioGym
+from scenario_gym.metrics.rss import RSS, RSSDistances
+
+def test_add_rss(all_scenarios):
+    """Test adding the RSS metric to the scenario."""
+    s = all_scenarios["3fee6507-fd24-432f-b781-ca5676c834ef"]
+    gym = ScenarioGym(
+        state_callbacks=[
+            RSSDistances()
+        ],
+        metrics=[
+            RSS(),
+        ]
+    )
+    gym.load_scenario(s)
+    gym.rollout()
+
+    data = gym.get_metrics()
+    assert "RSS_safe_longitudinal" in data and "RSS_safe_lateral" in data, "Name did not get applied."
+    assert len(data) == 2, "Incorrect number of metrics returned."
+    assert type(data["RSS_safe_longitudinal"]) is bool, "Non-boolean RSS metric output for safe longitudinal distance."
+    assert type(data["RSS_safe_lateral"]) is bool, "Non-boolean RSS metric output for safe lateral distance."

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,22 +1,27 @@
-from scenario_gym.scenario_gym import ScenarioGym
 from scenario_gym.metrics.rss import RSS, RSSDistances
+from scenario_gym.scenario_gym import ScenarioGym
+
 
 def test_add_rss(all_scenarios):
     """Test adding the RSS metric to the scenario."""
     s = all_scenarios["3fee6507-fd24-432f-b781-ca5676c834ef"]
     gym = ScenarioGym(
-        state_callbacks=[
-            RSSDistances()
-        ],
+        state_callbacks=[RSSDistances()],
         metrics=[
             RSS(),
-        ]
+        ],
     )
     gym.load_scenario(s)
     gym.rollout()
 
     data = gym.get_metrics()
-    assert "RSS_safe_longitudinal" in data and "RSS_safe_lateral" in data, "Name did not get applied."
+    assert (
+        "RSS_safe_longitudinal" in data and "RSS_safe_lateral" in data
+    ), "Name did not get applied."
     assert len(data) == 2, "Incorrect number of metrics returned."
-    assert type(data["RSS_safe_longitudinal"]) is bool, "Non-boolean RSS metric output for safe longitudinal distance."
-    assert type(data["RSS_safe_lateral"]) is bool, "Non-boolean RSS metric output for safe lateral distance."
+    assert (
+        type(data["RSS_safe_longitudinal"]) is bool
+    ), "Non-boolean RSS metric output for safe longitudinal distance."
+    assert (
+        type(data["RSS_safe_lateral"]) is bool
+    ), "Non-boolean RSS metric output for safe lateral distance."


### PR DESCRIPTION
Added first two RSS metric annotations.

These correspond to the first two rules of RSS which are 
1) Maintain a safe longitudinal distance such that the ego / hazard is able to come to a stop before hitting the car ahead / be hit by the car behind in the worst reasonable braking scenario
2) Maintain a safe lateral distance such that the ego is able to avoid collision with a car moving laterally relative to it in the worst reasonable braking scenario