### PR TITLE
Immutable trajectory data

### DIFF
--- a/scenario_gym/trajectory.py
+++ b/scenario_gym/trajectory.py
@@ -10,13 +10,15 @@ from scenario_gym.road_network import RoadNetwork
 
 class Trajectory:
     """
-    A ScenarioGym representation of a trajectory.
+    A Scenario Gym representation of a trajectory.
 
-    Note taht trajectories consist of immutable arrays. To modify a trajectory
+    Note that trajectories consist of immutable arrays. To modify a trajectory
     one must copy the data and init a new one:
-        new_data = trajectory.data.cop()
-        # apply changes
-        new_t = Trajectory(new_data)
+    ```
+    new_data = trajectory.data.copy()
+    # apply changes
+    new_t = Trajectory(new_data)
+    ```
     """
 
     _fields = ["t", "x", "y", "z", "h", "p", "r"]

--- a/scenario_gym/trajectory.py
+++ b/scenario_gym/trajectory.py
@@ -9,7 +9,15 @@ from scenario_gym.road_network import RoadNetwork
 
 
 class Trajectory:
-    """A ScenarioGym representation of a trajectory."""
+    """
+    A ScenarioGym representation of a trajectory.
+
+    Note taht trajectories consist of immutable arrays. To modify a trajectory
+    one must copy the data and init a new one:
+        new_data = trajectory.data.cop()
+        # apply changes
+        new_t = Trajectory(new_data)
+    """
 
     _fields = ["t", "x", "y", "z", "h", "p", "r"]
     t: Optional[NDArray] = None
@@ -64,7 +72,11 @@ class Trajectory:
                     )
             _data.append(d)
             setattr(self, f, d)
+
+        # we will make the data readonly
         self.data = np.unique(np.array(_data).T, axis=0)
+        self.data.flags.writeable = False
+
         self._interpolated: Optional[Callable[[ArrayLike], NDArray]] = None
         self._interpolated_s: Optional[Callable[[ArrayLike], NDArray]] = None
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     name="scenario_gym",
     packages=find_packages(
         where=".",
-        include=["scenario_gym"],
+        include=["scenario_gym", "scenario_gym.*"],
     ),
     version="0.1.0",
 )

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest as pt
 
 from scenario_gym.trajectory import Trajectory, _resolve_heading
 
@@ -46,3 +47,12 @@ def test_resolve_heading():
     assert (
         np.abs(np.diff(delta)).sum() <= np.abs(np.diff(data)).sum()
     ), "Stepwise distance should be reduced."
+
+
+def test_immutable_traj():
+    """Test that trajectories are copied correctly."""
+    data = np.repeat(np.arange(10, dtype=np.float32)[:, None], 4, axis=1)  # (10, 4)
+    traj = Trajectory(data, fields=["t", "x", "y", "h"])
+
+    with pt.raises(ValueError):
+        traj.data[-1][0] = 11


### PR DESCRIPTION
As discussed, it seems safer to enforce that trajectories are immutable in order to enforce that silent errors are created.