### PR TITLE
support File objects

### DIFF
--- a/tests/input_files/Catalogs/Custom_Catalog/MiscCatalogs/CustomCatalog.xosc
+++ b/tests/input_files/Catalogs/Custom_Catalog/MiscCatalogs/CustomCatalog.xosc
@@ -5,6 +5,8 @@
     <CustomObject objectCategory="misc" name="misc_object">
       <Properties>
         <Property name="prop" value="64"/>
+        <File filepath="test.txt"/>
+        <File filepath="test2.txt"/>
       </Properties>
       <BoundingBox>
         <Center x="1.37" y="0" z="0.65" />

--- a/tests/test_catalog_entry.py
+++ b/tests/test_catalog_entry.py
@@ -49,3 +49,4 @@ def test_custom_catalog(all_catalogs):
     ent = out["misc_object"]
     assert ent.catalog_entry.catalog_entry == "misc_object"
     assert ent.catalog_entry.mystery_property == 100
+    assert set(ent.catalog_entry.files) == set(["test.txt", "test2.txt"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from scenario_gym.trajectory import Trajectory
 def collision_scenario():
     """Create a scenario with two entities that collide."""
     box = BoundingBox(2.0, 5.0, 0.0, 0.0)
-    ce = CatalogEntry("car", "car", "car", "car", box, {})
+    ce = CatalogEntry("car", "car", "car", "car", box, {}, [])
     ego = Entity(ce, ref="ego")
     hazard = Entity(ce, ref="entity_1")
 


### PR DESCRIPTION
Adds support for `File` objects in the `Properties` fields of catalog entries. This will break any code that manually constructs catalog entries (however `develop` already does this compared to `main`).