### PR TITLE
Mixed catalogs

### DIFF
--- a/scenario_gym/utils.py
+++ b/scenario_gym/utils.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 from shapely.geometry import Polygon
@@ -30,7 +31,9 @@ def detect_geom_collisions(
 
     """
     all_geoms = geoms if others is None else geoms + others
-    tree = STRtree(all_geoms)
+    with warnings.catch_warnings():  # STRTree not included in Shapely 2.0
+        warnings.simplefilter("ignore")
+        tree = STRtree(all_geoms)
     return {
         id(g): [
             g_prime

--- a/scenario_gym/xosc_interface/catalogs.py
+++ b/scenario_gym/xosc_interface/catalogs.py
@@ -42,6 +42,15 @@ def read_catalog(
         catalogs. Can be used for reading custom objects from catalog files. Must
         be immutable or lru_cache
 
+    Returns
+    -------
+    catalog_name : str
+        The name of the catalog from the Catalog element.
+
+    entries : Dict[str, Entity]
+        A dictionary mapping each entry name to an entity with that catalog entry.
+        These can then be cloned to create entities using the chosen catalog entry.
+
     """
     if entity_types is None:
         entity_types = DEFAULT_ENTITY_TYPES

--- a/scenario_gym/xosc_interface/read.py
+++ b/scenario_gym/xosc_interface/read.py
@@ -48,8 +48,8 @@ def import_scenario(
     # Read catalogs:
     catalogs: Dict[str, Dict[str, Entity]] = {}
     for catalog_location in osc_root.iterfind("CatalogLocations/"):
-        catalog_path = catalog_location.find("Directory").attrib["path"]
-        catalog_path = os.path.join(cwd, catalog_path)
+        rel_catalog_path = catalog_location.find("Directory").attrib["path"]
+        catalog_path = os.path.join(cwd, rel_catalog_path)
         for catalog_file in os.listdir(catalog_path):
             if catalog_file.endswith(".xosc"):
                 name, entries = read_catalog(
@@ -57,6 +57,7 @@ def import_scenario(
                     entity_types=entity_types,
                 )
                 catalogs[name] = entries
+                scenario.add_catalog_location(name, rel_catalog_path)
 
     # Import road network:
     scene_graph_file = osc_root.find("RoadNetwork/SceneGraphFile")

--- a/scenario_gym/xosc_interface/write.py
+++ b/scenario_gym/xosc_interface/write.py
@@ -13,7 +13,7 @@ from scenario_gym.xosc_interface.utils import is_stationary
 def write_scenario(
     scenario: Scenario,
     filepath: str,
-    base_catalog_path: str = "../Catalogs/Scenario_Gym",
+    base_catalog_path: str = "../Catalogs/",
     base_road_network_path: str = "../Road_Networks",
     osc_minor_version: int = 0,
 ) -> None:
@@ -49,7 +49,7 @@ def write_scenario(
         if ce.catalog_type not in catalog.catalogs:
             catalog_dir = os.path.join(
                 base_catalog_path,
-                f"{ce.catalog_type}Catalogs",
+                scenario.catalog_locations[ce.catalog_name],
             )
             catalog.add_catalog(f"{ce.catalog_type}Catalog", catalog_dir)
         catalog_ref = xosc.CatalogReference(ce.catalog_name, ce.catalog_entry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def all_scenarios():
         "e1bdb607-206b-4f40-9bc4-59ded182ecc8",
         "e56ae853-4266-4c30-865f-96737d87b601",
         "fbb6b5ca-3fcb-4a7b-9757-b8554a753e69",
+        "mixed_catalogs",
     ]
     base = os.path.join(os.path.dirname(__file__), "input_files", "Scenarios")
     scenarios = {f: os.path.join(base, f + ".xosc") for f in scenarios}

--- a/tests/input_files/Scenarios/mixed_catalogs.xosc
+++ b/tests/input_files/Scenarios/mixed_catalogs.xosc
@@ -1,0 +1,2880 @@
+<OpenSCENARIO>
+    <FileHeader description="dRISK scenario 1518e754-318f-4847-8a30-2dce552b4504 subject to the dRISK License Agreement (https://drisk.ai/license/)" author="&#8706;RISK" revMajor="1" revMinor="0" date="2022-04-11T12:36:20.208694"/>
+    <ParameterDeclarations/>
+    <CatalogLocations>
+        <VehicleCatalog>
+            <Directory path="../Catalogs/Scenario_Gym/VehicleCatalogs"/>
+        </VehicleCatalog>
+        <MiscObjectCatalog>
+            <Directory path="../Catalogs/Custom_Catalog/MiscCatalogs"/>
+        </MiscObjectCatalog>
+    </CatalogLocations>
+    <RoadNetwork>
+        <SceneGraphFile filepath="../Road_Networks/Greenwich_Road_Network_002.json"/>
+    </RoadNetwork>
+    <Entities>
+        <ScenarioObject name="ego">
+            <CatalogReference catalogName="ScenarioGymVehicleCatalog" entryName="car1"/>
+        </ScenarioObject>
+        <ScenarioObject name="entity_1">
+            <CatalogReference catalogName="ScenarioGymVehicleCatalog" entryName="car1"/>
+        </ScenarioObject>
+        <ScenarioObject name="entity_2">
+            <CatalogReference catalogName="CustomCatalog" entryName="misc_object"/>
+        </ScenarioObject>
+        <ScenarioObject name="entity_3">
+            <CatalogReference catalogName="CustomCatalog" entryName="misc_object"/>
+        </ScenarioObject>
+    </Entities>
+    <Storyboard>
+        <Init>
+            <Actions/>
+        </Init>
+        <Story name="cee5856a-1ced-45ff-9b1c-6c494d89c55e_JamCams_00001.07555_2020-06-14T17_51_4301_00_ego_1_simulation_2021-11-12-10_11_19">
+            <ParameterDeclarations>
+                <ParameterDeclaration name="$minimalTimeToCollision" parameterType="double" value="1.5"/>
+            </ParameterDeclarations>
+            <Act name="cee5856a-1ced-45ff-9b1c-6c494d89c55e_JamCams_00001.07555_2020-06-14T17_51_4301_00_ego_1_simulation_2021-11-12-10_11_19">
+                <ManeuverGroup name="ego_maneuver_group" maximumExecutionCount="1">
+                    <Actors selectTriggeringEntities="false">
+                        <EntityRef entityRef="ego"/>
+                    </Actors>
+                    <Maneuver name="ego_maneuver">
+                        <Event name="ego_follow_trajectory_event" priority="overwrite" maximumExecutionCount="1">
+                            <Action name="follow_trajectory_action">
+                                <PrivateAction>
+                                    <RoutingAction>
+                                        <FollowTrajectoryAction>
+                                            <Trajectory name="ego_trajectory" closed="false">
+                                                <ParameterDeclarations/>
+                                                <Shape>
+                                                    <Polyline>
+                                                        <Vertex time="2.18">
+                                                            <Position>
+                                                                <WorldPosition x="557.154" y="366.3076" z="0.0933" h="2.9454" p="-0.0028" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.3">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0929" h="2.9454" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.42">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0933" h="2.9453" p="-0.0025" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.52">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0934" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.64">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0933" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.74">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0932" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.86">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0933" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.96">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0933" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.08">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0933" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.2">
+                                                            <Position>
+                                                                <WorldPosition x="557.1541" y="366.3076" z="0.0933" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.3">
+                                                            <Position>
+                                                                <WorldPosition x="557.154" y="366.3076" z="0.0932" h="2.9453" p="-0.0026" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.42">
+                                                            <Position>
+                                                                <WorldPosition x="557.1497" y="366.3085" z="0.0924" h="2.9455" p="-0.0032" r="0.0126"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.52">
+                                                            <Position>
+                                                                <WorldPosition x="557.1224" y="366.3135" z="0.0882" h="2.9464" p="-0.0064" r="0.0121"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.64">
+                                                            <Position>
+                                                                <WorldPosition x="557.0175" y="366.3338" z="0.0817" h="2.9517" p="-0.0113" r="0.0117"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.74">
+                                                            <Position>
+                                                                <WorldPosition x="556.8616" y="366.3636" z="0.0816" h="2.9608" p="-0.0116" r="0.0116"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.86">
+                                                            <Position>
+                                                                <WorldPosition x="556.5901" y="366.412" z="0.0843" h="2.9715" p="-0.0103" r="0.0122"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.98">
+                                                            <Position>
+                                                                <WorldPosition x="556.2269" y="366.472" z="0.0863" h="2.976" p="-0.0097" r="0.0132"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.1">
+                                                            <Position>
+                                                                <WorldPosition x="555.7727" y="366.5449" z="0.0872" h="2.9768" p="-0.0099" r="0.0114"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.22">
+                                                            <Position>
+                                                                <WorldPosition x="555.2298" y="366.6353" z="0.0872" h="2.9833" p="-0.0088" r="0.0143"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.34">
+                                                            <Position>
+                                                                <WorldPosition x="554.6061" y="366.7323" z="0.0888" h="2.9796" p="-0.0062" r="0.0131"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.44">
+                                                            <Position>
+                                                                <WorldPosition x="554.0341" y="366.8258" z="0.0905" h="2.9877" p="-0.0056" r="0.0088"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.56">
+                                                            <Position>
+                                                                <WorldPosition x="553.293" y="366.9387" z="0.0949" h="2.9891" p="-0.0032" r="0.0149"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.68">
+                                                            <Position>
+                                                                <WorldPosition x="552.509" y="367.061" z="0.0962" h="2.9847" p="0.0019" r="0.0046"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.8">
+                                                            <Position>
+                                                                <WorldPosition x="551.7165" y="367.1842" z="0.0957" h="2.998" p="0.0039" r="0.013"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.9">
+                                                            <Position>
+                                                                <WorldPosition x="551.0638" y="367.2766" z="0.1012" h="2.9828" p="0.0075" r="0.0115"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.02">
+                                                            <Position>
+                                                                <WorldPosition x="550.2949" y="367.4012" z="0.0955" h="2.9946" p="0.0087" r="0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.14">
+                                                            <Position>
+                                                                <WorldPosition x="549.535" y="367.5096" z="0.0863" h="2.9926" p="0.0057" r="0.0115"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.26">
+                                                            <Position>
+                                                                <WorldPosition x="548.7617" y="367.6313" z="0.0844" h="2.9885" p="0.0042" r="-0.0022"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.38">
+                                                            <Position>
+                                                                <WorldPosition x="547.9664" y="367.7507" z="0.0771" h="3.0006" p="0.0047" r="0.0098"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.5">
+                                                            <Position>
+                                                                <WorldPosition x="547.1767" y="367.8631" z="0.0744" h="2.9838" p="0.006" r="-0.0033"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.62">
+                                                            <Position>
+                                                                <WorldPosition x="546.3866" y="367.9914" z="0.0718" h="2.9979" p="0.0038" r="0.0036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.74">
+                                                            <Position>
+                                                                <WorldPosition x="545.5569" y="368.1088" z="0.0583" h="2.9823" p="-0.0021" r="0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.86">
+                                                            <Position>
+                                                                <WorldPosition x="544.715" y="368.2465" z="0.0599" h="2.9907" p="-0.0002" r="-0.0026"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.96">
+                                                            <Position>
+                                                                <WorldPosition x="544.019" y="368.3512" z="0.0652" h="2.9801" p="0.0031" r="0.0053"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.08">
+                                                            <Position>
+                                                                <WorldPosition x="543.1886" y="368.4901" z="0.0605" h="2.9753" p="0.0006" r="-0.0052"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.2">
+                                                            <Position>
+                                                                <WorldPosition x="542.3301" y="368.6315" z="0.0541" h="2.9781" p="-0.0041" r="0.006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.32">
+                                                            <Position>
+                                                                <WorldPosition x="541.4583" y="368.7774" z="0.0586" h="2.9653" p="-0.0009" r="-0.0045"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.42">
+                                                            <Position>
+                                                                <WorldPosition x="540.7396" y="368.9071" z="0.0627" h="2.9754" p="0.0022" r="-0.0025"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.54">
+                                                            <Position>
+                                                                <WorldPosition x="539.8661" y="369.0531" z="0.0587" h="2.9725" p="-0.0011" r="0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.66">
+                                                            <Position>
+                                                                <WorldPosition x="538.9481" y="369.2117" z="0.052" h="2.981" p="-0.0059" r="-0.0031"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.78">
+                                                            <Position>
+                                                                <WorldPosition x="537.9744" y="369.3673" z="0.052" h="2.9868" p="-0.0059" r="0.0026"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.9">
+                                                            <Position>
+                                                                <WorldPosition x="536.9481" y="369.5279" z="0.0543" h="2.9875" p="-0.0043" r="-0.0041"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.0">
+                                                            <Position>
+                                                                <WorldPosition x="536.0675" y="369.6622" z="0.0566" h="2.995" p="-0.0024" r="0.002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.12">
+                                                            <Position>
+                                                                <WorldPosition x="534.9717" y="369.8228" z="0.0557" h="2.9949" p="-0.0034" r="-0.0023"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.24">
+                                                            <Position>
+                                                                <WorldPosition x="533.8464" y="369.9868" z="0.0559" h="3.0035" p="-0.0037" r="-0.0014"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.36">
+                                                            <Position>
+                                                                <WorldPosition x="532.6787" y="370.1463" z="0.0552" h="3.0038" p="-0.006" r="0.0014"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.46">
+                                                            <Position>
+                                                                <WorldPosition x="531.6778" y="370.2831" z="0.0557" h="3.0072" p="-0.0057" r="-0.0005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.58">
+                                                            <Position>
+                                                                <WorldPosition x="530.4482" y="370.4462" z="0.0613" h="3.0072" p="-0.0031" r="0.0059"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.7">
+                                                            <Position>
+                                                                <WorldPosition x="529.2143" y="370.6158" z="0.066" h="2.9976" p="0.0013" r="0.0032"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.82">
+                                                            <Position>
+                                                                <WorldPosition x="527.9925" y="370.7961" z="0.0697" h="2.9902" p="0.0043" r="0.0062"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.94">
+                                                            <Position>
+                                                                <WorldPosition x="526.7837" y="370.9831" z="0.0652" h="2.9807" p="0.0036" r="0.0057"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.059999">
+                                                            <Position>
+                                                                <WorldPosition x="525.5894" y="371.18" z="0.0627" h="2.9723" p="0.0037" r="0.0069"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.16">
+                                                            <Position>
+                                                                <WorldPosition x="524.6049" y="371.3496" z="0.0594" h="2.9656" p="0.0034" r="0.0062"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.26">
+                                                            <Position>
+                                                                <WorldPosition x="523.6301" y="371.5248" z="0.0579" h="2.959" p="0.0024" r="0.0062"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.38">
+                                                            <Position>
+                                                                <WorldPosition x="522.4732" y="371.7406" z="0.0548" h="2.9519" p="0.0014" r="0.0048"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.5">
+                                                            <Position>
+                                                                <WorldPosition x="521.3303" y="371.9624" z="0.0545" h="2.9466" p="-0.0002" r="0.0038"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.62">
+                                                            <Position>
+                                                                <WorldPosition x="520.2015" y="372.1869" z="0.0546" h="2.9424" p="-0.0003" r="0.0025"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.72">
+                                                            <Position>
+                                                                <WorldPosition x="519.2709" y="372.3743" z="0.0562" h="2.9471" p="-0.0006" r="-0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.84">
+                                                            <Position>
+                                                                <WorldPosition x="518.1644" y="372.5896" z="0.0582" h="2.9521" p="0.0" r="0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.96">
+                                                            <Position>
+                                                                <WorldPosition x="517.0695" y="372.7978" z="0.0604" h="2.9585" p="0.0004" r="-0.001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.08">
+                                                            <Position>
+                                                                <WorldPosition x="515.9855" y="372.9958" z="0.061" h="2.9661" p="0.0007" r="-0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.2">
+                                                            <Position>
+                                                                <WorldPosition x="514.9122" y="373.1835" z="0.062" h="2.9735" p="0.0012" r="-0.001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.3">
+                                                            <Position>
+                                                                <WorldPosition x="514.0259" y="373.3323" z="0.0625" h="2.9797" p="0.0014" r="-0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.42">
+                                                            <Position>
+                                                                <WorldPosition x="512.9716" y="373.502" z="0.0618" h="2.9864" p="0.001" r="-0.0007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.54">
+                                                            <Position>
+                                                                <WorldPosition x="511.9142" y="373.6644" z="0.0589" h="2.9928" p="-0.0011" r="-0.0007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.66">
+                                                            <Position>
+                                                                <WorldPosition x="510.828" y="373.8237" z="0.0558" h="2.9971" p="-0.0035" r="-0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.76">
+                                                            <Position>
+                                                                <WorldPosition x="509.9072" y="373.9482" z="0.0569" h="2.9996" p="-0.0156" r="-0.0418"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.88">
+                                                            <Position>
+                                                                <WorldPosition x="508.8147" y="374.1175" z="0.0671" h="2.9912" p="-0.0197" r="-0.0028"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.0">
+                                                            <Position>
+                                                                <WorldPosition x="507.7415" y="374.2721" z="0.0705" h="2.97" p="0.0075" r="-0.0081"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.12">
+                                                            <Position>
+                                                                <WorldPosition x="506.6907" y="374.4739" z="0.1335" h="2.9389" p="0.0346" r="-0.0155"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.24">
+                                                            <Position>
+                                                                <WorldPosition x="505.6349" y="374.686" z="0.1287" h="2.8944" p="0.0063" r="-0.0537"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.34">
+                                                            <Position>
+                                                                <WorldPosition x="504.7723" y="374.9206" z="0.0814" h="2.8756" p="-0.0226" r="-0.0111"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.46">
+                                                            <Position>
+                                                                <WorldPosition x="503.7672" y="375.1856" z="0.0564" h="2.8643" p="0.0003" r="-0.0262"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.58">
+                                                            <Position>
+                                                                <WorldPosition x="502.7861" y="375.481" z="0.1051" h="2.8616" p="0.0252" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.7">
+                                                            <Position>
+                                                                <WorldPosition x="501.7973" y="375.7652" z="0.0656" h="2.8565" p="0.0006" r="0.0011"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.8">
+                                                            <Position>
+                                                                <WorldPosition x="500.9888" y="376.0035" z="0.0519" h="2.8529" p="-0.0045" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.92">
+                                                            <Position>
+                                                                <WorldPosition x="500.0344" y="376.2889" z="0.0602" h="2.8453" p="0.0009" r="0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.04">
+                                                            <Position>
+                                                                <WorldPosition x="499.0924" y="376.5797" z="0.0643" h="2.8365" p="0.0023" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.16">
+                                                            <Position>
+                                                                <WorldPosition x="498.1631" y="376.8747" z="0.0624" h="2.83" p="0.001" r="0.0009"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.28">
+                                                            <Position>
+                                                                <WorldPosition x="497.2473" y="377.172" z="0.0614" h="2.8234" p="0.0009" r="0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.38">
+                                                            <Position>
+                                                                <WorldPosition x="496.4942" y="377.4215" z="0.0619" h="2.819" p="0.001" r="0.0005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.5">
+                                                            <Position>
+                                                                <WorldPosition x="495.6018" y="377.7216" z="0.0622" h="2.8138" p="0.0011" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.62">
+                                                            <Position>
+                                                                <WorldPosition x="494.7219" y="378.0228" z="0.0621" h="2.8099" p="0.001" r="0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.74">
+                                                            <Position>
+                                                                <WorldPosition x="493.8539" y="378.3233" z="0.062" h="2.8068" p="0.001" r="0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.84">
+                                                            <Position>
+                                                                <WorldPosition x="493.1395" y="378.5728" z="0.0621" h="2.8048" p="0.001" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.96">
+                                                            <Position>
+                                                                <WorldPosition x="492.2926" y="378.8706" z="0.0621" h="2.803" p="0.001" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.08">
+                                                            <Position>
+                                                                <WorldPosition x="491.4569" y="379.1655" z="0.0619" h="2.8086" p="0.0012" r="-0.0023"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.2">
+                                                            <Position>
+                                                                <WorldPosition x="490.6293" y="379.4489" z="0.0619" h="2.8164" p="0.0011" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.3">
+                                                            <Position>
+                                                                <WorldPosition x="489.946" y="379.6778" z="0.0622" h="2.8221" p="0.0009" r="-0.0014"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.42">
+                                                            <Position>
+                                                                <WorldPosition x="489.1343" y="379.9439" z="0.062" h="2.8317" p="0.0011" r="-0.0007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.54">
+                                                            <Position>
+                                                                <WorldPosition x="488.3304" y="380.1985" z="0.062" h="2.8407" p="0.0011" r="-0.0009"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.66">
+                                                            <Position>
+                                                                <WorldPosition x="487.5364" y="380.4423" z="0.0623" h="2.8501" p="0.0013" r="-0.001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.78">
+                                                            <Position>
+                                                                <WorldPosition x="486.755" y="380.6741" z="0.0628" h="2.86" p="0.0016" r="-0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.88">
+                                                            <Position>
+                                                                <WorldPosition x="486.1148" y="380.8577" z="0.063" h="2.8674" p="0.0017" r="-0.0007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.0">
+                                                            <Position>
+                                                                <WorldPosition x="485.3615" y="381.0672" z="0.0632" h="2.8756" p="0.0018" r="-0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.12">
+                                                            <Position>
+                                                                <WorldPosition x="484.6244" y="381.266" z="0.063" h="2.8828" p="0.0017" r="-0.0005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.24">
+                                                            <Position>
+                                                                <WorldPosition x="483.9007" y="381.4557" z="0.0625" h="2.8889" p="0.0013" r="-0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.34">
+                                                            <Position>
+                                                                <WorldPosition x="483.3071" y="381.6078" z="0.0624" h="2.893" p="0.0012" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.46">
+                                                            <Position>
+                                                                <WorldPosition x="482.5984" y="381.78" z="0.0614" h="2.8955" p="-0.0172" r="-0.041"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.58">
+                                                            <Position>
+                                                                <WorldPosition x="481.9123" y="381.9554" z="0.0677" h="2.8982" p="-0.0235" r="-0.036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.7">
+                                                            <Position>
+                                                                <WorldPosition x="481.2594" y="382.1167" z="0.069" h="2.9018" p="-0.0162" r="-0.0376"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.82">
+                                                            <Position>
+                                                                <WorldPosition x="480.6479" y="382.2654" z="0.0696" h="2.9023" p="-0.0117" r="-0.037"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.92">
+                                                            <Position>
+                                                                <WorldPosition x="480.1776" y="382.3817" z="0.106" h="2.9041" p="0.0015" r="-0.0621"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.04">
+                                                            <Position>
+                                                                <WorldPosition x="479.6493" y="382.5378" z="0.1435" h="2.9078" p="0.0215" r="-0.028"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.16">
+                                                            <Position>
+                                                                <WorldPosition x="479.1249" y="382.6639" z="0.1255" h="2.9123" p="0.0267" r="-0.0179"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.28">
+                                                            <Position>
+                                                                <WorldPosition x="478.6097" y="382.7846" z="0.1103" h="2.9096" p="0.0219" r="-0.0225"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.38">
+                                                            <Position>
+                                                                <WorldPosition x="478.1958" y="382.8838" z="0.1129" h="2.9087" p="0.0203" r="-0.022"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.5">
+                                                            <Position>
+                                                                <WorldPosition x="477.7134" y="382.9993" z="0.1167" h="2.9064" p="0.0204" r="-0.0215"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.62">
+                                                            <Position>
+                                                                <WorldPosition x="477.2154" y="383.126" z="0.0833" h="2.9045" p="0.006" r="0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.74">
+                                                            <Position>
+                                                                <WorldPosition x="476.6443" y="383.2609" z="0.035" h="2.9" p="-0.0143" r="0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.86">
+                                                            <Position>
+                                                                <WorldPosition x="475.9906" y="383.4221" z="0.0428" h="2.8965" p="-0.0108" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.96">
+                                                            <Position>
+                                                                <WorldPosition x="475.4313" y="383.5628" z="0.0635" h="2.8947" p="0.0007" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.08">
+                                                            <Position>
+                                                                <WorldPosition x="474.7754" y="383.7293" z="0.0687" h="2.8927" p="0.0049" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.2">
+                                                            <Position>
+                                                                <WorldPosition x="474.1381" y="383.8924" z="0.0631" h="2.891" p="0.002" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.32">
+                                                            <Position>
+                                                                <WorldPosition x="473.5215" y="384.0513" z="0.0623" h="2.8895" p="0.0012" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.42">
+                                                            <Position>
+                                                                <WorldPosition x="473.0221" y="384.1807" z="0.063" h="2.8885" p="0.0015" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.54">
+                                                            <Position>
+                                                                <WorldPosition x="472.4198" y="384.3377" z="0.0604" h="2.8878" p="-0.0005" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.66">
+                                                            <Position>
+                                                                <WorldPosition x="471.8181" y="384.4948" z="0.06" h="2.8873" p="-0.0007" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.78">
+                                                            <Position>
+                                                                <WorldPosition x="471.2176" y="384.6518" z="0.0614" h="2.8869" p="0.0004" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.88">
+                                                            <Position>
+                                                                <WorldPosition x="470.7144" y="384.7836" z="0.0604" h="2.8868" p="-0.0004" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.0">
+                                                            <Position>
+                                                                <WorldPosition x="470.1069" y="384.9427" z="0.0603" h="2.8867" p="-0.0004" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.1">
+                                                            <Position>
+                                                                <WorldPosition x="469.6035" y="385.0743" z="0.0615" h="2.8868" p="0.0004" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.22">
+                                                            <Position>
+                                                                <WorldPosition x="469.0044" y="385.2309" z="0.0619" h="2.8868" p="0.0007" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.32">
+                                                            <Position>
+                                                                <WorldPosition x="468.5056" y="385.3611" z="0.0607" h="2.8869" p="-0.0002" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.42">
+                                                            <Position>
+                                                                <WorldPosition x="467.9914" y="385.4951" z="0.0575" h="2.8869" p="-0.0026" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.52">
+                                                            <Position>
+                                                                <WorldPosition x="467.4699" y="385.6309" z="0.0589" h="2.8869" p="-0.0015" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.64">
+                                                            <Position>
+                                                                <WorldPosition x="466.8477" y="385.7928" z="0.0622" h="2.887" p="0.001" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.74">
+                                                            <Position>
+                                                                <WorldPosition x="466.3342" y="385.9264" z="0.0625" h="2.887" p="0.0012" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.84">
+                                                            <Position>
+                                                                <WorldPosition x="465.8266" y="386.0583" z="0.0621" h="2.887" p="0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.94">
+                                                            <Position>
+                                                                <WorldPosition x="465.326" y="386.1884" z="0.062" h="2.887" p="0.0008" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.06">
+                                                            <Position>
+                                                                <WorldPosition x="464.7342" y="386.342" z="0.0621" h="2.887" p="0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.16">
+                                                            <Position>
+                                                                <WorldPosition x="464.2433" y="386.4694" z="0.0609" h="2.8871" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.26">
+                                                            <Position>
+                                                                <WorldPosition x="463.7288" y="386.603" z="0.0554" h="2.8872" p="-0.0041" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.38">
+                                                            <Position>
+                                                                <WorldPosition x="463.0827" y="386.7706" z="0.0564" h="2.8873" p="-0.0033" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.48">
+                                                            <Position>
+                                                                <WorldPosition x="462.5538" y="386.9077" z="0.064" h="2.8873" p="0.0023" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.58">
+                                                            <Position>
+                                                                <WorldPosition x="462.0492" y="387.0383" z="0.0677" h="2.8873" p="0.005" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.68">
+                                                            <Position>
+                                                                <WorldPosition x="461.5586" y="387.1653" z="0.0644" h="2.8873" p="0.0026" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.8">
+                                                            <Position>
+                                                                <WorldPosition x="460.9861" y="387.3136" z="0.0621" h="2.8873" p="0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.9">
+                                                            <Position>
+                                                                <WorldPosition x="460.5224" y="387.4337" z="0.0627" h="2.8873" p="0.0013" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.0">
+                                                            <Position>
+                                                                <WorldPosition x="460.0659" y="387.5519" z="0.0621" h="2.8873" p="0.0008" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                    </Polyline>
+                                                </Shape>
+                                            </Trajectory>
+                                            <TimeReference>
+                                                <Timing domainAbsoluteRelative="absolute" scale="1.0" offset="0.0"/>
+                                            </TimeReference>
+                                            <TrajectoryFollowingMode followingMode="position"/>
+                                        </FollowTrajectoryAction>
+                                    </RoutingAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="startSimTrigger" delay="0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="0" rule="greaterThan"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                </ManeuverGroup>
+                <ManeuverGroup name="entity_1_maneuver_group" maximumExecutionCount="1">
+                    <Actors selectTriggeringEntities="false">
+                        <EntityRef entityRef="entity_1"/>
+                    </Actors>
+                    <Maneuver name="entity_1_maneuver">
+                        <Event name="entity_1_follow_trajectory_event" priority="overwrite" maximumExecutionCount="1">
+                            <Action name="follow_trajectory_action">
+                                <PrivateAction>
+                                    <RoutingAction>
+                                        <FollowTrajectoryAction>
+                                            <Trajectory name="entity_1_trajectory" closed="false">
+                                                <ParameterDeclarations/>
+                                                <Shape>
+                                                    <Polyline>
+                                                        <Vertex time="2.18">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0035" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.3">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0492" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.42">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0496" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.52">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0496" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.64">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.74">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.86">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="2.96">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.08">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.2">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.3">
+                                                            <Position>
+                                                                <WorldPosition x="561.5875" y="360.9469" z="0.0495" h="3.0358" p="0.0036" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.42">
+                                                            <Position>
+                                                                <WorldPosition x="561.5844" y="360.9473" z="0.0488" h="3.036" p="0.0031" r="0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.52">
+                                                            <Position>
+                                                                <WorldPosition x="561.5637" y="360.9491" z="0.0452" h="3.0365" p="0.0005" r="0.0081"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.64">
+                                                            <Position>
+                                                                <WorldPosition x="561.4706" y="360.9578" z="0.0367" h="3.0402" p="-0.0055" r="0.0076"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.74">
+                                                            <Position>
+                                                                <WorldPosition x="561.3232" y="360.972" z="0.0338" h="3.0479" p="-0.0073" r="0.0074"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.86">
+                                                            <Position>
+                                                                <WorldPosition x="561.06" y="360.9949" z="0.0337" h="3.0585" p="-0.0071" r="0.0094"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="3.98">
+                                                            <Position>
+                                                                <WorldPosition x="560.7029" y="361.0203" z="0.0376" h="3.0648" p="-0.0049" r="0.0108"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.1">
+                                                            <Position>
+                                                                <WorldPosition x="560.2535" y="361.0496" z="0.0399" h="3.066" p="-0.0028" r="0.0114"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.22">
+                                                            <Position>
+                                                                <WorldPosition x="559.7139" y="361.0862" z="0.0333" h="3.0654" p="-0.0038" r="0.0133"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.34">
+                                                            <Position>
+                                                                <WorldPosition x="559.0881" y="361.1286" z="0.0266" h="3.053" p="-0.0052" r="0.0127"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.44">
+                                                            <Position>
+                                                                <WorldPosition x="558.5134" y="361.1785" z="0.0285" h="3.0544" p="-0.0044" r="0.0106"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.56">
+                                                            <Position>
+                                                                <WorldPosition x="557.7694" y="361.2406" z="0.0335" h="3.048" p="-0.002" r="0.0171"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.68">
+                                                            <Position>
+                                                                <WorldPosition x="556.9702" y="361.3147" z="0.026" h="3.0365" p="-0.0043" r="0.0075"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.8">
+                                                            <Position>
+                                                                <WorldPosition x="556.1411" y="361.4004" z="0.027" h="3.0439" p="-0.003" r="0.0178"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="4.9">
+                                                            <Position>
+                                                                <WorldPosition x="555.4526" y="361.4661" z="0.0345" h="3.0257" p="-0.0003" r="0.0166"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.02">
+                                                            <Position>
+                                                                <WorldPosition x="554.6396" y="361.5624" z="0.0355" h="3.0329" p="-0.0005" r="0.007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.14">
+                                                            <Position>
+                                                                <WorldPosition x="553.8414" y="361.6465" z="0.0341" h="3.025" p="-0.0021" r="0.0173"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.26">
+                                                            <Position>
+                                                                <WorldPosition x="553.0625" y="361.7419" z="0.039" h="3.0182" p="-0.0033" r="0.0036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.38">
+                                                            <Position>
+                                                                <WorldPosition x="552.3005" y="361.8342" z="0.0432" h="3.0255" p="-0.0007" r="0.0149"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.5">
+                                                            <Position>
+                                                                <WorldPosition x="551.545" y="361.9233" z="0.0405" h="3.0077" p="-0.0037" r="0.0026"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.62">
+                                                            <Position>
+                                                                <WorldPosition x="550.76" y="362.0339" z="0.0413" h="3.0255" p="-0.0082" r="0.0079"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.74">
+                                                            <Position>
+                                                                <WorldPosition x="549.9407" y="362.1256" z="0.0458" h="3.0143" p="-0.004" r="0.005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.86">
+                                                            <Position>
+                                                                <WorldPosition x="549.1208" y="362.233" z="0.0506" h="3.0172" p="-0.0021" r="0.0033"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.96">
+                                                            <Position>
+                                                                <WorldPosition x="548.4455" y="362.3168" z="0.0593" h="3.0076" p="0.0011" r="0.0069"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.08">
+                                                            <Position>
+                                                                <WorldPosition x="547.6237" y="362.4312" z="0.052" h="3.0064" p="-0.0026" r="-0.0027"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.2">
+                                                            <Position>
+                                                                <WorldPosition x="546.7712" y="362.5447" z="0.0504" h="3.0078" p="-0.0052" r="0.007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.32">
+                                                            <Position>
+                                                                <WorldPosition x="545.9208" y="362.6602" z="0.0619" h="2.9976" p="0.0015" r="-0.0038"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.42">
+                                                            <Position>
+                                                                <WorldPosition x="545.2172" y="362.7637" z="0.0589" h="3.0071" p="0.0008" r="-0.0019"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.54">
+                                                            <Position>
+                                                                <WorldPosition x="544.3602" y="362.88" z="0.0558" h="2.9944" p="-0.0022" r="0.0042"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.66">
+                                                            <Position>
+                                                                <WorldPosition x="543.4861" y="363.0139" z="0.0578" h="2.994" p="-0.0018" r="-0.0037"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.78">
+                                                            <Position>
+                                                                <WorldPosition x="542.6188" y="363.141" z="0.0616" h="2.9908" p="0.0015" r="0.0045"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.9">
+                                                            <Position>
+                                                                <WorldPosition x="541.7631" y="363.2741" z="0.0623" h="2.9839" p="0.0017" r="-0.0042"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.0">
+                                                            <Position>
+                                                                <WorldPosition x="541.0396" y="363.3887" z="0.058" h="2.9865" p="-0.0017" r="0.0036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.12">
+                                                            <Position>
+                                                                <WorldPosition x="540.1642" y="363.5258" z="0.0589" h="2.9769" p="-0.0008" r="-0.0021"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.24">
+                                                            <Position>
+                                                                <WorldPosition x="539.3011" y="363.6702" z="0.0625" h="2.9834" p="0.0018" r="-0.0013"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.36">
+                                                            <Position>
+                                                                <WorldPosition x="538.431" y="363.8101" z="0.0588" h="2.9758" p="-0.0009" r="0.0019"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.46">
+                                                            <Position>
+                                                                <WorldPosition x="537.6951" y="363.9351" z="0.0577" h="2.9765" p="-0.0018" r="-0.0027"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.58">
+                                                            <Position>
+                                                                <WorldPosition x="536.8181" y="364.0798" z="0.0614" h="2.9784" p="0.0009" r="0.0022"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.7">
+                                                            <Position>
+                                                                <WorldPosition x="535.9257" y="364.2285" z="0.0575" h="2.9789" p="-0.0021" r="-0.0021"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.82">
+                                                            <Position>
+                                                                <WorldPosition x="534.9831" y="364.3838" z="0.0519" h="2.9834" p="-0.0062" r="0.0018"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.94">
+                                                            <Position>
+                                                                <WorldPosition x="533.9856" y="364.5424" z="0.0525" h="2.9797" p="-0.0057" r="-0.002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.059999">
+                                                            <Position>
+                                                                <WorldPosition x="532.9536" y="364.7099" z="0.0572" h="2.9859" p="-0.0023" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.16">
+                                                            <Position>
+                                                                <WorldPosition x="532.0668" y="364.8476" z="0.0566" h="2.9835" p="-0.0022" r="0.0023"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.26">
+                                                            <Position>
+                                                                <WorldPosition x="531.1543" y="364.9941" z="0.0553" h="2.9844" p="-0.0019" r="-0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.38">
+                                                            <Position>
+                                                                <WorldPosition x="530.0299" y="365.1697" z="0.0564" h="2.9868" p="0.0005" r="0.0036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.5">
+                                                            <Position>
+                                                                <WorldPosition x="528.8677" y="365.3503" z="0.0521" h="2.9865" p="0.0018" r="0.003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.62">
+                                                            <Position>
+                                                                <WorldPosition x="527.6741" y="365.5347" z="0.0492" h="2.9881" p="0.0041" r="0.0044"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.72">
+                                                            <Position>
+                                                                <WorldPosition x="526.6615" y="365.6913" z="0.0422" h="2.9853" p="0.0042" r="0.006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.84">
+                                                            <Position>
+                                                                <WorldPosition x="525.4499" y="365.8836" z="0.0395" h="2.9828" p="0.0059" r="0.0058"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.96">
+                                                            <Position>
+                                                                <WorldPosition x="524.2491" y="366.077" z="0.0317" h="2.98" p="0.0037" r="0.0057"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.08">
+                                                            <Position>
+                                                                <WorldPosition x="523.0604" y="366.2723" z="0.0273" h="2.9769" p="-0.0004" r="0.0055"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.2">
+                                                            <Position>
+                                                                <WorldPosition x="521.87" y="366.4716" z="0.0217" h="2.9741" p="-0.0056" r="0.0036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.3">
+                                                            <Position>
+                                                                <WorldPosition x="520.878" y="366.6404" z="0.027" h="2.9716" p="-0.0067" r="0.0037"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.42">
+                                                            <Position>
+                                                                <WorldPosition x="519.6936" y="366.8449" z="0.0328" h="2.9693" p="-0.0064" r="0.0014"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.54">
+                                                            <Position>
+                                                                <WorldPosition x="518.5091" y="367.0523" z="0.0428" h="2.9673" p="-0.0058" r="0.0013"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.66">
+                                                            <Position>
+                                                                <WorldPosition x="517.3276" y="367.2618" z="0.0486" h="2.9657" p="-0.0045" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.76">
+                                                            <Position>
+                                                                <WorldPosition x="516.3361" y="367.4391" z="0.0551" h="2.9648" p="-0.0032" r="0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.88">
+                                                            <Position>
+                                                                <WorldPosition x="515.1497" y="367.6524" z="0.0599" h="2.9562" p="0.0002" r="0.0029"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.0">
+                                                            <Position>
+                                                                <WorldPosition x="513.9761" y="367.8773" z="0.0631" h="2.943" p="0.0021" r="0.0008"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.12">
+                                                            <Position>
+                                                                <WorldPosition x="512.8023" y="368.1177" z="0.0603" h="2.9321" p="-0.0003" r="0.0015"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.24">
+                                                            <Position>
+                                                                <WorldPosition x="511.6382" y="368.3691" z="0.0607" h="2.9216" p="0.0004" r="0.0008"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.34">
+                                                            <Position>
+                                                                <WorldPosition x="510.6685" y="368.5884" z="0.0598" h="2.9147" p="-0.0003" r="0.001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.46">
+                                                            <Position>
+                                                                <WorldPosition x="509.5033" y="368.8604" z="0.06" h="2.9075" p="-0.0003" r="0.0008"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.58">
+                                                            <Position>
+                                                                <WorldPosition x="508.3501" y="369.1379" z="0.0621" h="2.902" p="0.0012" r="0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.7">
+                                                            <Position>
+                                                                <WorldPosition x="507.1998" y="369.4209" z="0.0603" h="2.8981" p="-0.0001" r="0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.8">
+                                                            <Position>
+                                                                <WorldPosition x="506.2431" y="369.6597" z="0.0603" h="2.8959" p="-0.0002" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.92">
+                                                            <Position>
+                                                                <WorldPosition x="505.0979" y="369.9479" z="0.0603" h="2.8956" p="-0.0002" r="-0.0005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.04">
+                                                            <Position>
+                                                                <WorldPosition x="503.9459" y="370.2363" z="0.0597" h="2.8964" p="-0.0006" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.16">
+                                                            <Position>
+                                                                <WorldPosition x="502.7971" y="370.5225" z="0.0607" h="2.898" p="0.0001" r="-0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.28">
+                                                            <Position>
+                                                                <WorldPosition x="501.6349" y="370.8095" z="0.0585" h="2.9" p="-0.0014" r="-0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.38">
+                                                            <Position>
+                                                                <WorldPosition x="500.6669" y="371.047" z="0.0604" h="2.9024" p="0.0" r="-0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.5">
+                                                            <Position>
+                                                                <WorldPosition x="499.5095" y="371.3276" z="0.0613" h="2.905" p="0.0006" r="-0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.62">
+                                                            <Position>
+                                                                <WorldPosition x="498.3384" y="371.6082" z="0.0584" h="2.9073" p="-0.0016" r="-0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.74">
+                                                            <Position>
+                                                                <WorldPosition x="497.169" y="371.8859" z="0.0609" h="2.9094" p="0.0003" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.84">
+                                                            <Position>
+                                                                <WorldPosition x="496.1974" y="372.1145" z="0.0613" h="2.9111" p="0.0006" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.96">
+                                                            <Position>
+                                                                <WorldPosition x="495.018" y="372.3896" z="0.0584" h="2.9126" p="-0.0016" r="-0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.08">
+                                                            <Position>
+                                                                <WorldPosition x="493.8409" y="372.6633" z="0.0609" h="2.9123" p="0.0003" r="0.0006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.2">
+                                                            <Position>
+                                                                <WorldPosition x="492.6701" y="372.9378" z="0.0613" h="2.9111" p="0.0006" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.3">
+                                                            <Position>
+                                                                <WorldPosition x="491.688" y="373.1693" z="0.0592" h="2.9101" p="-0.001" r="0.0004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.42">
+                                                            <Position>
+                                                                <WorldPosition x="490.5157" y="373.4468" z="0.0611" h="2.908" p="0.0004" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.54">
+                                                            <Position>
+                                                                <WorldPosition x="489.344" y="373.7271" z="0.0601" h="2.9062" p="-0.0003" r="0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.66">
+                                                            <Position>
+                                                                <WorldPosition x="488.1685" y="374.0105" z="0.06" h="2.9041" p="-0.0004" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.78">
+                                                            <Position>
+                                                                <WorldPosition x="487.001" y="374.2944" z="0.0614" h="2.9022" p="0.0006" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.88">
+                                                            <Position>
+                                                                <WorldPosition x="486.0224" y="374.5344" z="0.0594" h="2.9009" p="-0.0008" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.0">
+                                                            <Position>
+                                                                <WorldPosition x="484.8514" y="374.8231" z="0.0608" h="2.8993" p="0.0002" r="0.0002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.12">
+                                                            <Position>
+                                                                <WorldPosition x="483.6841" y="375.1129" z="0.0606" h="2.8981" p="0.0" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.24">
+                                                            <Position>
+                                                                <WorldPosition x="482.5105" y="375.4056" z="0.0596" h="2.8971" p="-0.0007" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.34">
+                                                            <Position>
+                                                                <WorldPosition x="481.5391" y="375.6487" z="0.0614" h="2.8965" p="0.0006" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.46">
+                                                            <Position>
+                                                                <WorldPosition x="480.3565" y="375.9456" z="0.0579" h="2.8958" p="-0.046" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.58">
+                                                            <Position>
+                                                                <WorldPosition x="479.1911" y="376.2386" z="0.065" h="2.8959" p="-0.049" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.7">
+                                                            <Position>
+                                                                <WorldPosition x="478.0418" y="376.5227" z="0.1516" h="2.8984" p="0.0064" r="-0.006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.82">
+                                                            <Position>
+                                                                <WorldPosition x="476.8792" y="376.8257" z="0.2053" h="2.9051" p="0.0603" r="0.0025"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.92">
+                                                            <Position>
+                                                                <WorldPosition x="475.8745" y="377.0741" z="0.165" h="2.9012" p="0.0452" r="-0.0028"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.04">
+                                                            <Position>
+                                                                <WorldPosition x="474.6541" y="377.3759" z="0.0654" h="2.9015" p="0.0006" r="-0.0013"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.16">
+                                                            <Position>
+                                                                <WorldPosition x="473.4503" y="377.6722" z="0.0325" h="2.8999" p="-0.0103" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.28">
+                                                            <Position>
+                                                                <WorldPosition x="472.2629" y="377.9665" z="0.0621" h="2.898" p="0.0013" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.38">
+                                                            <Position>
+                                                                <WorldPosition x="471.2769" y="378.2125" z="0.069" h="2.8973" p="0.0032" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.5">
+                                                            <Position>
+                                                                <WorldPosition x="470.1004" y="378.5068" z="0.0619" h="2.8964" p="0.0008" r="0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.62">
+                                                            <Position>
+                                                                <WorldPosition x="468.9342" y="378.7995" z="0.0598" h="2.8959" p="0.0003" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.74">
+                                                            <Position>
+                                                                <WorldPosition x="467.7701" y="379.0924" z="0.0599" h="2.8956" p="-0.0005" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.86">
+                                                            <Position>
+                                                                <WorldPosition x="466.5919" y="379.3893" z="0.0584" h="2.8957" p="-0.0018" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.96">
+                                                            <Position>
+                                                                <WorldPosition x="465.6075" y="379.637" z="0.0599" h="2.8957" p="-0.0005" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.08">
+                                                            <Position>
+                                                                <WorldPosition x="464.4317" y="379.9328" z="0.0618" h="2.8957" p="0.001" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.2">
+                                                            <Position>
+                                                                <WorldPosition x="463.2638" y="380.2264" z="0.0618" h="2.8958" p="0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.32">
+                                                            <Position>
+                                                                <WorldPosition x="462.0994" y="380.519" z="0.0603" h="2.8958" p="-0.0002" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.42">
+                                                            <Position>
+                                                                <WorldPosition x="461.1189" y="380.7653" z="0.058" h="2.8958" p="-0.0019" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.54">
+                                                            <Position>
+                                                                <WorldPosition x="459.936" y="381.0622" z="0.0594" h="2.8958" p="-0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.66">
+                                                            <Position>
+                                                                <WorldPosition x="458.7577" y="381.3578" z="0.0618" h="2.8959" p="0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.78">
+                                                            <Position>
+                                                                <WorldPosition x="457.587" y="381.6515" z="0.0619" h="2.8959" p="0.001" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.88">
+                                                            <Position>
+                                                                <WorldPosition x="456.6172" y="381.8947" z="0.0612" h="2.8959" p="0.0005" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.0">
+                                                            <Position>
+                                                                <WorldPosition x="455.4478" y="382.1877" z="0.0587" h="2.8959" p="-0.0014" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.1">
+                                                            <Position>
+                                                                <WorldPosition x="454.4631" y="382.4344" z="0.0581" h="2.8959" p="-0.0018" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.22">
+                                                            <Position>
+                                                                <WorldPosition x="453.2821" y="382.7303" z="0.0609" h="2.896" p="0.0002" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.32">
+                                                            <Position>
+                                                                <WorldPosition x="452.303" y="382.9756" z="0.062" h="2.896" p="0.0011" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.42">
+                                                            <Position>
+                                                                <WorldPosition x="451.3295" y="383.2194" z="0.0618" h="2.896" p="0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.52">
+                                                            <Position>
+                                                                <WorldPosition x="450.3604" y="383.462" z="0.061" h="2.896" p="0.0003" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.64">
+                                                            <Position>
+                                                                <WorldPosition x="449.1888" y="383.7551" z="0.0583" h="2.896" p="-0.0017" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.74">
+                                                            <Position>
+                                                                <WorldPosition x="448.2038" y="384.0016" z="0.0585" h="2.896" p="-0.0015" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.84">
+                                                            <Position>
+                                                                <WorldPosition x="447.2203" y="384.2477" z="0.0609" h="2.896" p="0.0002" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.94">
+                                                            <Position>
+                                                                <WorldPosition x="446.2416" y="384.4926" z="0.062" h="2.896" p="0.0011" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.06">
+                                                            <Position>
+                                                                <WorldPosition x="445.0744" y="384.7845" z="0.0617" h="2.896" p="0.0008" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.16">
+                                                            <Position>
+                                                                <WorldPosition x="444.1035" y="385.0273" z="0.0603" h="2.896" p="-0.0002" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.26">
+                                                            <Position>
+                                                                <WorldPosition x="443.1227" y="385.2727" z="0.058" h="2.896" p="-0.0019" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.38">
+                                                            <Position>
+                                                                <WorldPosition x="441.9394" y="385.5687" z="0.0594" h="2.896" p="-0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.48">
+                                                            <Position>
+                                                                <WorldPosition x="440.9566" y="385.8145" z="0.0616" h="2.896" p="0.0007" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.58">
+                                                            <Position>
+                                                                <WorldPosition x="439.979" y="386.0589" z="0.062" h="2.8961" p="0.0011" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.68">
+                                                            <Position>
+                                                                <WorldPosition x="439.0073" y="386.3019" z="0.0616" h="2.8961" p="0.0007" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.8">
+                                                            <Position>
+                                                                <WorldPosition x="437.8418" y="386.5933" z="0.0598" h="2.8961" p="-0.0006" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.9">
+                                                            <Position>
+                                                                <WorldPosition x="436.8595" y="386.8388" z="0.0579" h="2.8961" p="-0.002" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.0">
+                                                            <Position>
+                                                                <WorldPosition x="435.8737" y="387.0853" z="0.0594" h="2.8961" p="-0.0009" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                    </Polyline>
+                                                </Shape>
+                                            </Trajectory>
+                                            <TimeReference>
+                                                <Timing domainAbsoluteRelative="absolute" scale="1.0" offset="0.0"/>
+                                            </TimeReference>
+                                            <TrajectoryFollowingMode followingMode="position"/>
+                                        </FollowTrajectoryAction>
+                                    </RoutingAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="startSimTrigger" delay="0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="0" rule="greaterThan"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                </ManeuverGroup>
+                <ManeuverGroup name="entity_2_maneuver_group" maximumExecutionCount="1">
+                    <Actors selectTriggeringEntities="false">
+                        <EntityRef entityRef="entity_2"/>
+                    </Actors>
+                    <Maneuver name="entity_2_maneuver">
+                        <Event name="entity_2_follow_trajectory_event" priority="overwrite" maximumExecutionCount="1">
+                            <Action name="follow_trajectory_action">
+                                <PrivateAction>
+                                    <RoutingAction>
+                                        <FollowTrajectoryAction>
+                                            <Trajectory name="entity_2_trajectory" closed="false">
+                                                <ParameterDeclarations/>
+                                                <Shape>
+                                                    <Polyline>
+                                                        <Vertex time="5.14">
+                                                            <Position>
+                                                                <WorldPosition x="506.0197" y="365.5445" z="-0.0064" h="2.913" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.26">
+                                                            <Position>
+                                                                <WorldPosition x="505.8753" y="365.5782" z="-0.0064" h="2.9097" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.38">
+                                                            <Position>
+                                                                <WorldPosition x="505.7335" y="365.6115" z="-0.0064" h="2.9056" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.5">
+                                                            <Position>
+                                                                <WorldPosition x="505.5944" y="365.6448" z="-0.0064" h="2.9015" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.62">
+                                                            <Position>
+                                                                <WorldPosition x="505.4578" y="365.678" z="-0.0064" h="2.8973" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.74">
+                                                            <Position>
+                                                                <WorldPosition x="505.3388" y="365.7079" z="-0.0064" h="2.8818" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.86">
+                                                            <Position>
+                                                                <WorldPosition x="505.2758" y="365.7245" z="-0.0064" h="2.8691" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.96">
+                                                            <Position>
+                                                                <WorldPosition x="505.1471" y="365.7604" z="-0.0064" h="2.8638" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.08">
+                                                            <Position>
+                                                                <WorldPosition x="505.0445" y="365.7897" z="-0.0064" h="2.8573" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.2">
+                                                            <Position>
+                                                                <WorldPosition x="504.9445" y="365.819" z="-0.0064" h="2.8536" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.32">
+                                                            <Position>
+                                                                <WorldPosition x="504.8065" y="365.8598" z="-0.0064" h="2.8526" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.42">
+                                                            <Position>
+                                                                <WorldPosition x="504.784" y="365.8665" z="-0.0064" h="2.854" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.54">
+                                                            <Position>
+                                                                <WorldPosition x="504.6375" y="365.9097" z="-0.0064" h="2.8572" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.66">
+                                                            <Position>
+                                                                <WorldPosition x="504.4934" y="365.9516" z="-0.0064" h="2.8616" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.78">
+                                                            <Position>
+                                                                <WorldPosition x="504.3761" y="365.985" z="-0.0064" h="2.8816" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.9">
+                                                            <Position>
+                                                                <WorldPosition x="504.2723" y="366.0118" z="-0.0064" h="2.9044" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.0">
+                                                            <Position>
+                                                                <WorldPosition x="504.1494" y="366.0417" z="-0.0064" h="2.9142" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.12">
+                                                            <Position>
+                                                                <WorldPosition x="504.047" y="366.0644" z="-0.0064" h="2.9476" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.24">
+                                                            <Position>
+                                                                <WorldPosition x="503.9108" y="366.0919" z="-0.0064" h="2.9589" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.36">
+                                                            <Position>
+                                                                <WorldPosition x="503.8414" y="366.1045" z="-0.0064" h="2.9825" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.46">
+                                                            <Position>
+                                                                <WorldPosition x="503.7303" y="366.1221" z="-0.0064" h="2.9894" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.58">
+                                                            <Position>
+                                                                <WorldPosition x="503.5859" y="366.1445" z="-0.0064" h="2.9903" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.7">
+                                                            <Position>
+                                                                <WorldPosition x="503.4977" y="366.1579" z="-0.0064" h="2.9907" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.82">
+                                                            <Position>
+                                                                <WorldPosition x="503.4313" y="366.168" z="-0.0064" h="2.9864" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.94">
+                                                            <Position>
+                                                                <WorldPosition x="503.2989" y="366.1887" z="-0.0064" h="2.9732" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.059999">
+                                                            <Position>
+                                                                <WorldPosition x="503.2899" y="366.1902" z="-0.0064" h="2.9673" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.16">
+                                                            <Position>
+                                                                <WorldPosition x="503.1586" y="366.2138" z="-0.0064" h="2.9608" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.26">
+                                                            <Position>
+                                                                <WorldPosition x="503.0636" y="366.2313" z="-0.0064" h="2.9425" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.38">
+                                                            <Position>
+                                                                <WorldPosition x="502.9765" y="366.2492" z="-0.0064" h="2.9221" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.5">
+                                                            <Position>
+                                                                <WorldPosition x="502.8746" y="366.2722" z="-0.0064" h="2.8968" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.62">
+                                                            <Position>
+                                                                <WorldPosition x="502.8354" y="366.2818" z="-0.0064" h="2.8871" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.72">
+                                                            <Position>
+                                                                <WorldPosition x="502.715" y="366.3131" z="-0.0064" h="2.8846" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.84">
+                                                            <Position>
+                                                                <WorldPosition x="502.67" y="366.3249" z="-0.0064" h="2.886" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.96">
+                                                            <Position>
+                                                                <WorldPosition x="502.562" y="366.3531" z="-0.0064" h="2.8894" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.08">
+                                                            <Position>
+                                                                <WorldPosition x="502.4742" y="366.3755" z="-0.0064" h="2.912" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.2">
+                                                            <Position>
+                                                                <WorldPosition x="502.3776" y="366.3976" z="-0.0064" h="2.9253" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.3">
+                                                            <Position>
+                                                                <WorldPosition x="502.3068" y="366.4125" z="-0.0064" h="2.9534" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.42">
+                                                            <Position>
+                                                                <WorldPosition x="502.2579" y="366.4221" z="-0.0064" h="2.9809" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.54">
+                                                            <Position>
+                                                                <WorldPosition x="502.1507" y="366.4393" z="-0.0064" h="3.0007" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.66">
+                                                            <Position>
+                                                                <WorldPosition x="502.0755" y="366.4498" z="-0.0064" h="3.0262" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.76">
+                                                            <Position>
+                                                                <WorldPosition x="501.9629" y="366.4626" z="-0.0064" h="3.0344" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.88">
+                                                            <Position>
+                                                                <WorldPosition x="501.8105" y="366.4791" z="-0.0064" h="3.0375" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.0">
+                                                            <Position>
+                                                                <WorldPosition x="501.6649" y="366.4944" z="-0.0064" h="3.0381" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.12">
+                                                            <Position>
+                                                                <WorldPosition x="501.5123" y="366.5103" z="-0.0064" h="3.0378" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.24">
+                                                            <Position>
+                                                                <WorldPosition x="501.3692" y="366.5253" z="-0.0064" h="3.0368" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.34">
+                                                            <Position>
+                                                                <WorldPosition x="501.2597" y="366.5367" z="-0.0064" h="3.0368" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.46">
+                                                            <Position>
+                                                                <WorldPosition x="501.1075" y="366.5528" z="-0.0064" h="3.0353" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.58">
+                                                            <Position>
+                                                                <WorldPosition x="500.9842" y="366.566" z="-0.0064" h="3.0314" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.7">
+                                                            <Position>
+                                                                <WorldPosition x="500.8321" y="366.5829" z="-0.0064" h="3.0282" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.8">
+                                                            <Position>
+                                                                <WorldPosition x="500.7041" y="366.5976" z="-0.0064" h="3.0256" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.92">
+                                                            <Position>
+                                                                <WorldPosition x="500.5929" y="366.6104" z="-0.0064" h="3.0261" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.04">
+                                                            <Position>
+                                                                <WorldPosition x="500.4886" y="366.6224" z="-0.0064" h="3.0281" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.16">
+                                                            <Position>
+                                                                <WorldPosition x="500.3364" y="366.6396" z="-0.0064" h="3.0315" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.28">
+                                                            <Position>
+                                                                <WorldPosition x="500.2215" y="366.6516" z="-0.0064" h="3.0499" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.38">
+                                                            <Position>
+                                                                <WorldPosition x="500.1288" y="366.6599" z="-0.0064" h="3.0716" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.5">
+                                                            <Position>
+                                                                <WorldPosition x="500.0128" y="366.6678" z="-0.0064" h="3.0932" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.62">
+                                                            <Position>
+                                                                <WorldPosition x="499.9131" y="366.6728" z="-0.0064" h="3.1135" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.74">
+                                                            <Position>
+                                                                <WorldPosition x="499.7642" y="366.6769" z="-0.0064" h="3.1261" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.84">
+                                                            <Position>
+                                                                <WorldPosition x="499.7081" y="366.6778" z="-0.0064" h="3.1379" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.96">
+                                                            <Position>
+                                                                <WorldPosition x="499.5962" y="366.6781" z="-0.0064" h="3.1409" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.08">
+                                                            <Position>
+                                                                <WorldPosition x="499.4428" y="366.6783" z="-0.0064" h="3.1412" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.2">
+                                                            <Position>
+                                                                <WorldPosition x="499.2895" y="366.6784" z="-0.0064" h="3.1406" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.3">
+                                                            <Position>
+                                                                <WorldPosition x="499.17" y="366.6785" z="-0.0064" h="3.1394" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.42">
+                                                            <Position>
+                                                                <WorldPosition x="499.0168" y="366.6787" z="-0.0064" h="3.138" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.54">
+                                                            <Position>
+                                                                <WorldPosition x="498.8639" y="366.6792" z="-0.0064" h="3.1364" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.66">
+                                                            <Position>
+                                                                <WorldPosition x="498.7226" y="366.6798" z="-0.0064" h="3.1346" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.78">
+                                                            <Position>
+                                                                <WorldPosition x="498.5695" y="366.6808" z="-0.0064" h="3.1327" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.88">
+                                                            <Position>
+                                                                <WorldPosition x="498.4476" y="366.6817" z="-0.0064" h="3.1327" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.0">
+                                                            <Position>
+                                                                <WorldPosition x="498.3207" y="366.6828" z="-0.0064" h="3.1264" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.12">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6837" z="-0.0064" h="3.1223" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.24">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6837" z="-0.0064" h="3.1222" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.34">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1221" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.46">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1221" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.58">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.122" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.7">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.122" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.82">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.92">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.04">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.16">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.28">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.38">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.5">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.62">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.74">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.86">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.96">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.08">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.2">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.32">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.42">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.54">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.66">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.78">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.88">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.0">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.1">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.22">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.32">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.42">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.52">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.64">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.74">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.84">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.94">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.06">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.16">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.26">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.38">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.48">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.58">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.68">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.8">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.9">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.0">
+                                                            <Position>
+                                                                <WorldPosition x="498.2694" y="366.6836" z="-0.0064" h="3.1219" p="0.0" r="0.0"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                    </Polyline>
+                                                </Shape>
+                                            </Trajectory>
+                                            <TimeReference>
+                                                <Timing domainAbsoluteRelative="absolute" scale="1.0" offset="0.0"/>
+                                            </TimeReference>
+                                            <TrajectoryFollowingMode followingMode="position"/>
+                                        </FollowTrajectoryAction>
+                                    </RoutingAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="startSimTrigger" delay="0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="0" rule="greaterThan"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                </ManeuverGroup>
+                <ManeuverGroup name="entity_3_maneuver_group" maximumExecutionCount="1">
+                    <Actors selectTriggeringEntities="false">
+                        <EntityRef entityRef="entity_3"/>
+                    </Actors>
+                    <Maneuver name="entity_3_maneuver">
+                        <Event name="entity_3_follow_trajectory_event" priority="overwrite" maximumExecutionCount="1">
+                            <Action name="follow_trajectory_action">
+                                <PrivateAction>
+                                    <RoutingAction>
+                                        <FollowTrajectoryAction>
+                                            <Trajectory name="entity_3_trajectory" closed="false">
+                                                <ParameterDeclarations/>
+                                                <Shape>
+                                                    <Polyline>
+                                                        <Vertex time="5.14">
+                                                            <Position>
+                                                                <WorldPosition x="504.4717" y="366.3057" z="-0.0026" h="1.4383" p="-0.0176" r="-0.0149"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.26">
+                                                            <Position>
+                                                                <WorldPosition x="504.4641" y="366.308" z="-0.0052" h="1.4553" p="-0.0179" r="-0.0146"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.38">
+                                                            <Position>
+                                                                <WorldPosition x="504.4597" y="366.3083" z="-0.0019" h="1.4835" p="-0.0183" r="-0.0141"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.5">
+                                                            <Position>
+                                                                <WorldPosition x="504.4525" y="366.3108" z="-0.0007" h="1.5142" p="-0.0187" r="-0.0135"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.62">
+                                                            <Position>
+                                                                <WorldPosition x="504.4404" y="366.3146" z="0.0008" h="1.5353" p="-0.019" r="-0.0131"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.74">
+                                                            <Position>
+                                                                <WorldPosition x="504.4286" y="366.3643" z="-0.0008" h="1.5435" p="-0.0191" r="-0.013"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.86">
+                                                            <Position>
+                                                                <WorldPosition x="504.4087" y="366.3825" z="0.0375" h="1.4561" p="-0.0179" r="-0.0146"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="5.96">
+                                                            <Position>
+                                                                <WorldPosition x="504.4103" y="366.5205" z="0.0547" h="1.4876" p="-0.0183" r="-0.014"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.08">
+                                                            <Position>
+                                                                <WorldPosition x="504.4135" y="366.6898" z="0.0538" h="1.5496" p="-0.0192" r="-0.0129"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.2">
+                                                            <Position>
+                                                                <WorldPosition x="504.416" y="366.8407" z="0.0538" h="1.6184" p="-0.02" r="-0.0115"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.32">
+                                                            <Position>
+                                                                <WorldPosition x="504.4142" y="366.9703" z="0.0538" h="1.6916" p="-0.0208" r="-0.01"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.42">
+                                                            <Position>
+                                                                <WorldPosition x="504.4096" y="367.0648" z="0.0538" h="1.6845" p="-0.0207" r="-0.0102"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.54">
+                                                            <Position>
+                                                                <WorldPosition x="504.3915" y="367.1962" z="0.0538" h="1.7576" p="-0.0214" r="-0.0086"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.66">
+                                                            <Position>
+                                                                <WorldPosition x="504.363" y="367.3267" z="0.0538" h="1.8263" p="-0.0219" r="-0.0071"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.78">
+                                                            <Position>
+                                                                <WorldPosition x="504.326" y="367.459" z="0.0537" h="1.8979" p="-0.0224" r="-0.0056"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="6.9">
+                                                            <Position>
+                                                                <WorldPosition x="504.2827" y="367.5945" z="0.0537" h="1.9687" p="-0.0227" r="-0.004"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.0">
+                                                            <Position>
+                                                                <WorldPosition x="504.2346" y="367.7107" z="0.0537" h="2.0384" p="-0.0229" r="-0.0024"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.12">
+                                                            <Position>
+                                                                <WorldPosition x="504.1718" y="367.834" z="0.0537" h="2.1009" p="-0.0231" r="-0.0009"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.24">
+                                                            <Position>
+                                                                <WorldPosition x="504.1104" y="367.9503" z="0.0537" h="2.0992" p="-0.0231" r="-0.001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.36">
+                                                            <Position>
+                                                                <WorldPosition x="504.0389" y="368.071" z="0.0537" h="2.1645" p="-0.0231" r="0.0005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.46">
+                                                            <Position>
+                                                                <WorldPosition x="503.9627" y="368.1794" z="0.0537" h="2.2278" p="-0.023" r="0.002"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.58">
+                                                            <Position>
+                                                                <WorldPosition x="503.8511" y="368.3218" z="0.0537" h="2.2862" p="-0.0228" r="0.0033"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.7">
+                                                            <Position>
+                                                                <WorldPosition x="503.7042" y="368.4905" z="0.0537" h="2.3312" p="-0.0227" r="0.0044"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.82">
+                                                            <Position>
+                                                                <WorldPosition x="503.5496" y="368.6559" z="0.0537" h="2.361" p="-0.0225" r="0.005"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="7.94">
+                                                            <Position>
+                                                                <WorldPosition x="503.3899" y="368.8184" z="0.0537" h="2.3776" p="-0.0224" r="0.0054"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.059999">
+                                                            <Position>
+                                                                <WorldPosition x="503.2332" y="368.9695" z="0.0537" h="2.3811" p="-0.0224" r="0.0055"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.16">
+                                                            <Position>
+                                                                <WorldPosition x="503.0925" y="369.1035" z="0.0537" h="2.3822" p="-0.0224" r="0.0055"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.26">
+                                                            <Position>
+                                                                <WorldPosition x="502.9604" y="369.23" z="0.0537" h="2.3665" p="-0.0225" r="0.0052"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.38">
+                                                            <Position>
+                                                                <WorldPosition x="502.8038" y="369.3832" z="0.0537" h="2.3315" p="-0.0227" r="0.0044"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.5">
+                                                            <Position>
+                                                                <WorldPosition x="502.6422" y="369.549" z="0.0537" h="2.2883" p="-0.0228" r="0.0034"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.62">
+                                                            <Position>
+                                                                <WorldPosition x="502.4802" y="369.7274" z="0.0537" h="2.2913" p="-0.0228" r="0.0034"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.72">
+                                                            <Position>
+                                                                <WorldPosition x="502.3322" y="369.9039" z="0.0537" h="2.2439" p="-0.023" r="0.0024"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.84">
+                                                            <Position>
+                                                                <WorldPosition x="502.1627" y="370.1183" z="0.0537" h="2.1962" p="-0.023" r="0.0013"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="8.96">
+                                                            <Position>
+                                                                <WorldPosition x="502.0073" y="370.3395" z="0.0537" h="2.1526" p="-0.0231" r="0.0003"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.08">
+                                                            <Position>
+                                                                <WorldPosition x="501.8588" y="370.5696" z="0.0537" h="2.1112" p="-0.0231" r="-0.0007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.2">
+                                                            <Position>
+                                                                <WorldPosition x="501.7206" y="370.7977" z="0.0537" h="2.0738" p="-0.023" r="-0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.3">
+                                                            <Position>
+                                                                <WorldPosition x="501.6132" y="370.9857" z="0.0537" h="2.0407" p="-0.023" r="-0.0023"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.42">
+                                                            <Position>
+                                                                <WorldPosition x="501.489" y="371.219" z="0.0537" h="2.0398" p="-0.023" r="-0.0023"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.54">
+                                                            <Position>
+                                                                <WorldPosition x="501.4019" y="371.4029" z="0.0537" h="1.9995" p="-0.0228" r="-0.0033"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.66">
+                                                            <Position>
+                                                                <WorldPosition x="501.3294" y="371.5709" z="0.0537" h="1.962" p="-0.0227" r="-0.0041"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.76">
+                                                            <Position>
+                                                                <WorldPosition x="501.2733" y="371.7065" z="0.0537" h="1.9281" p="-0.0225" r="-0.0049"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="9.88">
+                                                            <Position>
+                                                                <WorldPosition x="501.2188" y="371.8579" z="0.0537" h="1.8997" p="-0.0224" r="-0.0055"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.0">
+                                                            <Position>
+                                                                <WorldPosition x="501.172" y="371.9999" z="0.0537" h="1.872" p="-0.0222" r="-0.0061"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.12">
+                                                            <Position>
+                                                                <WorldPosition x="501.1258" y="372.1471" z="0.0538" h="1.849" p="-0.0221" r="-0.0066"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.24">
+                                                            <Position>
+                                                                <WorldPosition x="501.0858" y="372.2843" z="0.0538" h="1.8234" p="-0.0219" r="-0.0072"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.34">
+                                                            <Position>
+                                                                <WorldPosition x="501.0564" y="372.3923" z="0.0538" h="1.8196" p="-0.0219" r="-0.0073"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.46">
+                                                            <Position>
+                                                                <WorldPosition x="501.0198" y="372.5461" z="0.0538" h="1.7948" p="-0.0217" r="-0.0078"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.58">
+                                                            <Position>
+                                                                <WorldPosition x="500.9867" y="372.6962" z="0.0538" h="1.7773" p="-0.0216" r="-0.0082"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.7">
+                                                            <Position>
+                                                                <WorldPosition x="500.9554" y="372.8468" z="0.0538" h="1.7635" p="-0.0214" r="-0.0085"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.8">
+                                                            <Position>
+                                                                <WorldPosition x="500.9306" y="372.9741" z="0.0538" h="1.7522" p="-0.0213" r="-0.0088"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="10.92">
+                                                            <Position>
+                                                                <WorldPosition x="500.9031" y="373.1257" z="0.0538" h="1.7421" p="-0.0213" r="-0.009"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.04">
+                                                            <Position>
+                                                                <WorldPosition x="500.8781" y="373.2709" z="0.0538" h="1.7347" p="-0.0212" r="-0.0091"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.16">
+                                                            <Position>
+                                                                <WorldPosition x="500.8405" y="373.4622" z="0.0538" h="1.8288" p="-0.022" r="-0.0071"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.28">
+                                                            <Position>
+                                                                <WorldPosition x="500.7775" y="373.7082" z="0.0537" h="1.88" p="-0.0223" r="-0.006"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.38">
+                                                            <Position>
+                                                                <WorldPosition x="500.6964" y="373.9578" z="0.0537" h="1.9433" p="-0.0226" r="-0.0045"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.5">
+                                                            <Position>
+                                                                <WorldPosition x="500.5811" y="374.2542" z="0.0537" h="2.006" p="-0.0229" r="-0.0031"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.62">
+                                                            <Position>
+                                                                <WorldPosition x="500.4526" y="374.5379" z="0.0537" h="2.0032" p="-0.0229" r="-0.0032"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.74">
+                                                            <Position>
+                                                                <WorldPosition x="500.3002" y="374.8368" z="0.0537" h="2.0495" p="-0.023" r="-0.0021"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.84">
+                                                            <Position>
+                                                                <WorldPosition x="500.1599" y="375.076" z="0.0537" h="2.0947" p="-0.023" r="-0.0011"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="11.96">
+                                                            <Position>
+                                                                <WorldPosition x="499.9892" y="375.3457" z="0.0537" h="2.138" p="-0.0231" r="-0.0001"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.08">
+                                                            <Position>
+                                                                <WorldPosition x="499.8071" y="375.6123" z="0.0537" h="2.1764" p="-0.0231" r="0.0008"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.2">
+                                                            <Position>
+                                                                <WorldPosition x="499.619" y="375.8737" z="0.0537" h="2.2086" p="-0.023" r="0.0016"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.3">
+                                                            <Position>
+                                                                <WorldPosition x="499.4628" y="376.0819" z="0.0537" h="2.2369" p="-0.023" r="0.0022"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.42">
+                                                            <Position>
+                                                                <WorldPosition x="499.2616" y="376.3364" z="0.0537" h="2.2604" p="-0.0229" r="0.0027"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.54">
+                                                            <Position>
+                                                                <WorldPosition x="499.0522" y="376.5888" z="0.0537" h="2.2797" p="-0.0229" r="0.0032"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.66">
+                                                            <Position>
+                                                                <WorldPosition x="498.8452" y="376.8297" z="0.0537" h="2.2987" p="-0.0228" r="0.0036"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.78">
+                                                            <Position>
+                                                                <WorldPosition x="498.6266" y="377.0718" z="0.0537" h="2.3216" p="-0.0227" r="0.0041"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="12.88">
+                                                            <Position>
+                                                                <WorldPosition x="498.4449" y="377.2644" z="0.0537" h="2.3239" p="-0.0227" r="0.0042"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.0">
+                                                            <Position>
+                                                                <WorldPosition x="498.2177" y="377.4962" z="0.0537" h="2.3472" p="-0.0226" r="0.0047"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.12">
+                                                            <Position>
+                                                                <WorldPosition x="497.9874" y="377.724" z="0.0537" h="2.369" p="-0.0225" r="0.0052"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.24">
+                                                            <Position>
+                                                                <WorldPosition x="497.7522" y="377.9472" z="0.0537" h="2.3898" p="-0.0224" r="0.0057"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.34">
+                                                            <Position>
+                                                                <WorldPosition x="497.5507" y="378.1317" z="0.0537" h="2.4097" p="-0.0222" r="0.0061"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.46">
+                                                            <Position>
+                                                                <WorldPosition x="497.305" y="378.3496" z="0.0537" h="2.4265" p="-0.0221" r="0.0065"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.58">
+                                                            <Position>
+                                                                <WorldPosition x="497.0613" y="378.5583" z="0.0536" h="2.4438" p="-0.022" r="0.0069"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.7">
+                                                            <Position>
+                                                                <WorldPosition x="496.8097" y="378.7656" z="0.0536" h="2.4601" p="-0.0219" r="0.0072"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.82">
+                                                            <Position>
+                                                                <WorldPosition x="496.5548" y="378.968" z="0.0536" h="2.4796" p="-0.0218" r="0.0077"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="13.92">
+                                                            <Position>
+                                                                <WorldPosition x="496.3509" y="379.1258" z="0.0536" h="2.5019" p="-0.0216" r="0.0081"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.04">
+                                                            <Position>
+                                                                <WorldPosition x="496.091" y="379.3193" z="0.0536" h="2.5262" p="-0.0214" r="0.0087"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.16">
+                                                            <Position>
+                                                                <WorldPosition x="495.8263" y="379.5067" z="0.0536" h="2.5501" p="-0.0212" r="0.0092"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.28">
+                                                            <Position>
+                                                                <WorldPosition x="495.5548" y="379.6889" z="0.0536" h="2.5725" p="-0.021" r="0.0096"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.38">
+                                                            <Position>
+                                                                <WorldPosition x="495.3309" y="379.8252" z="0.0564" h="2.5301" p="-0.0213" r="0.0087"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.5">
+                                                            <Position>
+                                                                <WorldPosition x="495.058" y="379.9109" z="0.0668" h="2.1113" p="-0.0231" r="-0.0007"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.62">
+                                                            <Position>
+                                                                <WorldPosition x="494.8542" y="379.9838" z="0.0792" h="1.7197" p="-0.0211" r="-0.0094"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.74">
+                                                            <Position>
+                                                                <WorldPosition x="494.7203" y="380.0963" z="0.1097" h="1.5277" p="-0.0189" r="-0.0133"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.86">
+                                                            <Position>
+                                                                <WorldPosition x="494.6895" y="380.2309" z="0.1138" h="1.6387" p="-0.0202" r="-0.0111"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="14.96">
+                                                            <Position>
+                                                                <WorldPosition x="494.6427" y="380.4562" z="0.1138" h="1.7808" p="-0.0216" r="-0.0081"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.08">
+                                                            <Position>
+                                                                <WorldPosition x="494.5424" y="380.7648" z="0.1137" h="1.935" p="-0.0226" r="-0.0047"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.2">
+                                                            <Position>
+                                                                <WorldPosition x="494.3886" y="381.075" z="0.1137" h="2.0927" p="-0.023" r="-0.0011"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.32">
+                                                            <Position>
+                                                                <WorldPosition x="494.1845" y="381.3348" z="0.1137" h="2.2668" p="-0.0229" r="0.0029"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.42">
+                                                            <Position>
+                                                                <WorldPosition x="493.9966" y="381.5107" z="0.1136" h="2.4333" p="-0.0221" r="0.0066"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.54">
+                                                            <Position>
+                                                                <WorldPosition x="493.7425" y="381.6947" z="0.1136" h="2.5745" p="-0.0209" r="0.0097"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.66">
+                                                            <Position>
+                                                                <WorldPosition x="493.4766" y="381.8514" z="0.1136" h="2.6955" p="-0.0196" r="0.0121"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.78">
+                                                            <Position>
+                                                                <WorldPosition x="493.2844" y="382.1626" z="0.1141" h="-3.1285" p="-0.0122" r="0.0196"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="15.88">
+                                                            <Position>
+                                                                <WorldPosition x="493.1242" y="382.218" z="0.1137" h="-2.7405" p="-0.0039" r="0.0227"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.0">
+                                                            <Position>
+                                                                <WorldPosition x="492.9633" y="382.2673" z="0.114" h="-2.0515" p="0.0115" r="0.02"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.1">
+                                                            <Position>
+                                                                <WorldPosition x="492.9443" y="382.2735" z="0.1135" h="-1.9467" p="0.0135" r="0.0187"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.22">
+                                                            <Position>
+                                                                <WorldPosition x="492.9435" y="382.2738" z="0.1136" h="-1.9377" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.32">
+                                                            <Position>
+                                                                <WorldPosition x="492.9435" y="382.2738" z="0.1136" h="-1.9368" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.42">
+                                                            <Position>
+                                                                <WorldPosition x="492.9434" y="382.2738" z="0.1136" h="-1.9363" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.52">
+                                                            <Position>
+                                                                <WorldPosition x="492.9434" y="382.2738" z="0.1136" h="-1.9361" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.64">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2738" z="0.1136" h="-1.9359" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.74">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9358" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.84">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9357" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="16.94">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9356" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.06">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.16">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.26">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.38">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.48">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.58">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.68">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.8">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="17.9">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.0">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.1">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.22">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.32">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.42">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.52">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.64">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.74">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.84">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="18.96">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.06">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.16">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.26">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.38">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.48">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.58">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.68">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.8">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="19.9">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.0">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.1">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.22">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.32">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.42">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.52">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.64">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.74">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.84">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                        <Vertex time="20.96">
+                                                            <Position>
+                                                                <WorldPosition x="492.9433" y="382.2739" z="0.1136" h="-1.9355" p="0.0137" r="0.0186"/>
+                                                            </Position>
+                                                        </Vertex>
+                                                    </Polyline>
+                                                </Shape>
+                                            </Trajectory>
+                                            <TimeReference>
+                                                <Timing domainAbsoluteRelative="absolute" scale="1.0" offset="0.0"/>
+                                            </TimeReference>
+                                            <TrajectoryFollowingMode followingMode="position"/>
+                                        </FollowTrajectoryAction>
+                                    </RoutingAction>
+                                </PrivateAction>
+                            </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="startSimTrigger" delay="0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="0" rule="greaterThan"/>
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                </ManeuverGroup>
+                <StartTrigger>
+                    <ConditionGroup>
+                        <Condition name="startSimTrigger" delay="0" conditionEdge="rising">
+                            <ByValueCondition>
+                                <SimulationTimeCondition value="0" rule="greaterThan"/>
+                            </ByValueCondition>
+                        </Condition>
+                    </ConditionGroup>
+                </StartTrigger>
+                <StopTrigger/>
+            </Act>
+        </Story>
+        <StopTrigger/>
+    </Storyboard>
+</OpenSCENARIO>

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -121,3 +121,26 @@ def test_all_stationary(all_scenarios) -> None:
         e.trajectory = Trajectory(np.zeros((1, 7)))
     gym.reset_scenario()
     gym.recorder.get_state()
+
+
+def test_mixed_catalogs(all_scenarios) -> None:
+    """Record and output a scenario with mixed catalog sets."""
+    scenario_path = all_scenarios["mixed_catalogs"]
+    out_path = scenario_path.replace("Scenarios", "Recordings").replace(
+        ".xosc", "_test.xosc"
+    )
+
+    # rollout and record
+    gym = ScenarioGym()
+    gym.record()
+    gym.load_scenario(scenario_path)
+    gym.rollout()
+    gym.recorder.write_xml(out_path=out_path)
+
+    old_locations = gym.state.scenario.catalog_locations.copy()
+
+    gym.load_scenario(out_path)
+
+    new_locations = gym.state.scenario.catalog_locations.copy()
+
+    assert old_locations == new_locations

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest as pt
 
@@ -37,8 +39,10 @@ def collision_scenario():
     )
 
     scenario = Scenario()
-    scenario.add_entity(ego)
-    scenario.add_entity(hazard)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        scenario.add_entity(ego)
+        scenario.add_entity(hazard)
     return scenario, ego, hazard
 
 


### PR DESCRIPTION
Adds support for mixed catalog sets and removes the need to specify the full catalog path when writing scenarios. Now catalogs are supplied via `add_catalog_locations`.