### PR TITLE
Fix flicker

### DIFF
--- a/scenario_gym/__init__.py
+++ b/scenario_gym/__init__.py
@@ -50,4 +50,4 @@ __all__ = [
     "xosc_interface",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(
         where=".",
         include=["scenario_gym", "scenario_gym.*"],
     ),
-    version="0.1.0",
+    version="0.2.0",
 )

--- a/tests/test__package.py
+++ b/tests/test__package.py
@@ -1,4 +1,6 @@
+"""Test package and module versions (file named so as to always run first)."""
 import os
+from pathlib import Path
 
 from packaging import version
 
@@ -18,7 +20,6 @@ def test_version():
         os.path.dirname(__file__),  # scenario_gym/tests
         "../setup.py",
     )
-    with open(setup_pth, "r") as f:
-        setup = f.read()
+    setup = Path(setup_pth).read_text()
     v_setup = version.parse(setup.split("version=")[-1].split(",")[0].strip("'\""))
     assert v_module == v_setup, "Setup version does not equal module version."

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -57,14 +57,11 @@ def test_metric_requires(scenario_path):
     try:
         gym.load_scenario(scenario_path)
     except ValueError as e:
-        print("Should not raise any value error:")
-        raise e
+        raise "Should not raise any value error:" from e
 
     gym = ScenarioGym(state_callbacks=[], metrics=[TestMetric()])
-    try:
+    with pt.raises(ValueError):
         gym.load_scenario(scenario_path)
-    except ValueError:
-        pass
 
 
 def test_callback_requires(scenario_path):
@@ -73,17 +70,12 @@ def test_callback_requires(scenario_path):
     try:
         gym.load_scenario(scenario_path)
     except ValueError as e:
-        print("Should not raise any value error:")
-        raise e
+        raise "Should not raise any value error:" from e
 
     gym = ScenarioGym(state_callbacks=[TestDependentCallback()])
-    try:
+    with pt.raises(ValueError):
         gym.load_scenario(scenario_path)
-    except ValueError:
-        pass
 
     gym = ScenarioGym(state_callbacks=[TestDependentCallback(), TestCallback()])
-    try:
+    with pt.raises(ValueError):
         gym.load_scenario(scenario_path)
-    except ValueError:
-        pass

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -49,11 +49,11 @@ def test_add_metric(all_scenarios):
     """Test adding a metric to the scenario."""
     files = [
         all_scenarios[s]
-        for s in [
+        for s in (
             "3fee6507-fd24-432f-b781-ca5676c834ef",
             "41dac6fa-6f83-461e-a145-08692da5f3c7",
             "9c324146-be03-4d4e-8112-eaf36af15c17",
-        ]
+        )
     ]
     manager = ScenarioManager()
     manager.add_metric(EgoMaxSpeedMetric())

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -44,7 +44,7 @@ def test_import_scenario(scenario_path):
     assert all((e.catalog_entry.catalog_category is not None for e in s.entities))
     assert s.road_network is not None
 
-    s = import_scenario(scenario_path, relabel=True)
+    s = import_scenario(scenario_path)
     e1, e2 = s.entities[1], s.entities[2]
     assert e1.ref[:-2] == e1.catalog_entry.catalog_category.lower()
     assert e2.ref[:-2] == e2.catalog_entry.catalog_category.lower()

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -19,7 +19,7 @@ def test_viewer(all_scenarios):
         background=(0, 100, 0),
     )
     gym.load_scenario(scenario_path)
-    for _ in range(10):
+    for _ in range(1):
         gym.rollout(render=True)
 
 


### PR DESCRIPTION
This PR fixes the flickering effect when rendering driveable surface boundaries. This was caused by caching of geometries coordinates. Geometries were cached using `id(geom)` which works fine for geometries fixed in memory e.g. the boundary and centre lines. For geometries accessed as properties of other shapely geometries such as interiors of polygons the id changes each time the geometry is queried meaning the cache failed and would often be replaced by another object.

To fix this I have just removed the caching where it uses a non-fixed geometry. This comes with a considerable performance loss:

On this branch:
```
$ pytest tests/test_speeds.py -s -k test_render_speed --speed_tests
tests/test_speeds.py Completed in 20.88s per scenario, 3.185e+04μs per step.
```

On main:
```
$ pytest tests/test_speeds.py -s -k test_render_speed --speed_tests
tests/test_speeds.py Completed in 4.248s per scenario, 6.479e+03μs per step.
```
This might be fixed by Shapely 2.0 as then geometries will be hashable however this is only in alpha release. I will investigate a different solution in the meantime.