### PR TITLE
Use the latest pyxodr version available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "matplotlib>=3.5.0",
     "numpy>=1.21.0",
     "opencv-python>=4.5.3.56",
-    "pyxodr==0.1.1",
+    "pyxodr>=0.1.2",
     "PyYAML>=6.0",
     "setuptools>=61.0.0",
     "scenariogeneration>=0.7.4",


### PR DESCRIPTION
Can we automate this?

I've set 0.1.2 as the minimum version as this fixes some bugs.