### PR TITLE
Scenario action trigger condition

### DIFF
--- a/scenario_gym/scenario/actions.py
+++ b/scenario_gym/scenario/actions.py
@@ -99,3 +99,22 @@ class UpdateStateVariableAction(ScenarioAction):
     def trigger_condition(self, state: State) -> bool:
         """Update when the state time is greater than action time."""
         return state.t > self.t
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Write the action to a dictionary."""
+        return {
+            "t": self.t,
+            "action_class": self.action_class,
+            "entity_ref": self.entity_ref,
+            "action_variables": self.action_variables,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]):
+        """Load the action from a dictionary."""
+        return cls(
+            data["t"],
+            data["action_class"],
+            data["entity_ref"],
+            data["action_variables"],
+        )

--- a/scenario_gym/scenario/actions.py
+++ b/scenario_gym/scenario/actions.py
@@ -18,18 +18,12 @@ class ScenarioAction(ABC):
 
     def __init__(
         self,
-        t: float,
         action_class: str,
         entity_ref: str,
         action_variables: Dict[str, Any],
     ):
         """
         Create the action.
-
-        Parameters
-        ----------
-        t : float
-            The time at which the action should be applied.
 
         action_class : str
             The name of the action class.
@@ -41,7 +35,6 @@ class ScenarioAction(ABC):
             Dictionary of action variables.
 
         """
-        self.t = t
         self.action_class = action_class
         self.entity_ref = entity_ref
         self.action_variables = action_variables
@@ -56,10 +49,14 @@ class ScenarioAction(ABC):
         """Apply the action to the environment state."""
         raise NotImplementedError
 
+    @abstractmethod
+    def trigger_condition(self, state: State) -> bool:
+        """Condition for when to apply the action."""
+        raise NotImplementedError
+
     def to_dict(self) -> Dict[str, Any]:
         """Write the action to a dictionary."""
         return {
-            "t": self.t,
             "action_class": self.action_class,
             "entity_ref": self.entity_ref,
             "action_variables": self.action_variables,
@@ -69,7 +66,6 @@ class ScenarioAction(ABC):
     def from_dict(cls, data: Dict[str, Any]):
         """Load the action from a dictionary."""
         return cls(
-            data["t"],
             data["action_class"],
             data["entity_ref"],
             data["action_variables"],
@@ -79,6 +75,19 @@ class ScenarioAction(ABC):
 class UpdateStateVariableAction(ScenarioAction):
     """Action that sets state variables for the entity."""
 
+    def __init__(self, t: float, *args, **kwargs):
+        """
+        Create the action.
+
+        Parameters
+        ----------
+        t : float
+            The time at which the action should be applied.
+
+        """
+        super().__init__(*args, **kwargs)
+        self.t = t
+
     def _apply(self, state: State, entity: Optional[Entity]) -> None:
         """Update the entity with action variables."""
         if entity is not None:
@@ -86,3 +95,7 @@ class UpdateStateVariableAction(ScenarioAction):
                 state.entity_state[entity] = {}
             for k, v in self.action_variables.items():
                 state.entity_state[entity][k] = v
+
+    def trigger_condition(self, state: State) -> bool:
+        """Update when the state time is greater than action time."""
+        return state.t > self.t

--- a/scenario_gym/scenario/scenario.py
+++ b/scenario_gym/scenario/scenario.py
@@ -13,7 +13,7 @@ from scenario_gym.entity import Entity
 from scenario_gym.entity.pedestrian import Pedestrian
 from scenario_gym.entity.vehicle import Vehicle
 from scenario_gym.road_network import RoadNetwork
-from scenario_gym.scenario.actions import ScenarioAction
+from scenario_gym.scenario.actions import ScenarioAction, UpdateStateVariableAction
 from scenario_gym.trajectory import Trajectory
 from scenario_gym.utils import cached_property
 
@@ -175,7 +175,7 @@ class Scenario:
         cls,
         data: Dict[str, Any],
         e_classes: Tuple[Type[Entity]] = (Vehicle, Pedestrian, Entity),
-        a_classes: Tuple[Type[ScenarioAction]] = (ScenarioAction,),
+        a_classes: Tuple[Type[ScenarioAction]] = (UpdateStateVariableAction,),
     ):
         """Load the scenario from a dictionary."""
         entities = []
@@ -192,7 +192,9 @@ class Scenario:
         actions = []
         for a_data in data.get("actions", ()):
             for Act in a_classes:
-                if Act.__name__ == a_data.get("action_class", ScenarioAction):
+                if Act.__name__ == a_data.get(
+                    "action_class", "UpdateStateVariableAction"
+                ):
                     break
             actions.append(Act.from_dict(a_data))
 
@@ -226,7 +228,7 @@ class Scenario:
         cls,
         path: str,
         e_classes: Tuple[Type[Entity]] = (Vehicle, Pedestrian, Entity),
-        a_classes: Tuple[Type[ScenarioAction]] = (ScenarioAction,),
+        a_classes: Tuple[Type[ScenarioAction]] = (UpdateStateVariableAction,),
     ):
         """Load the scenario from a json file."""
         with open(path, "r") as f:

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -8,13 +8,17 @@ import pytest as pt
 
 from scenario_gym.road_network import RoadNetwork
 from scenario_gym.scenario import Scenario
+from scenario_gym.scenario.actions import UpdateStateVariableAction
 from scenario_gym.xosc_interface import import_scenario
 
 
 @pt.fixture
 def example_scenario(all_scenarios):
     """Get a scenario to test."""
-    return import_scenario(all_scenarios["3e39a079-5653-440c-bcbe-24dc9f6bf0e6"])
+    s = import_scenario(all_scenarios["3e39a079-5653-440c-bcbe-24dc9f6bf0e6"])
+    action = UpdateStateVariableAction(2.0, "TestAction", "ego", {"var": 1.0})
+    s.add_action(action, inplace=True)
+    return s
 
 
 @pt.fixture


### PR DESCRIPTION
Extend `ScenarioAction` triggering logic.

Two main changes:
- Currently, `ScenarioAction` can only be trigger based on a time-component. This extends this to be triggered based on whatever custom subclass one wants.
- The time at which `ScenarioAction` are applied is also added to the state for use. 