### PR TITLE
Unique IDs for SG roads from xodr

### DIFF
--- a/scenario_gym/road_network/xodr.py
+++ b/scenario_gym/road_network/xodr.py
@@ -78,7 +78,7 @@ def road_to_sg(
                 old_to_new_lanes[lane] = sg_lane
 
         road = Road(
-            repr(xodr_road),
+            repr(xodr_lane_section),
             road_boundary,
             road_center,
             lanes=lanes,


### PR DESCRIPTION
The error here was `Road` IDs need to be unique, but we create multiple SG roads for each XODR road as we create one per lane section. Since the `Road` hash method uses the id, this resulted in "disappearing roads" during a set union operation downstream.

This was a pretty tricky bug to diagnose. @hamishs thoughts on adding a warning / error to `add_new_road_object` if a user tries to add roads to the same network with duplicated IDs?