### PR TITLE
Use inital velocity

### DIFF
--- a/scenario_gym/entity/base.py
+++ b/scenario_gym/entity/base.py
@@ -34,7 +34,9 @@ class Entity:
             raise NotImplementedError(
                 f"Subclass {cls.__name__} has no type annotation for catalog entry."
             ) from e
-        if not issubclass(ce_type, CatalogEntry):
+        if isinstance(ce_type, str) and ce_type == "CatalogEntry":
+            ce_type = CatalogEntry
+        elif isinstance(ce_type, str) or not issubclass(ce_type, CatalogEntry):
             raise TypeError("Catalog entry type must be a catalog entry subclass.")
         return ce_type
 

--- a/scenario_gym/road_network/xodr.py
+++ b/scenario_gym/road_network/xodr.py
@@ -66,11 +66,9 @@ def road_to_sg(
 
         xyz_centre = xodr_lane_section.get_offset_line()
         road_center = LineString(xyz_centre[:, :2])
-        assert xyz_centre[:, -1].min() > -100
         if simplify_tolerance is not None:
             road_center = road_center.simplify(simplify_tolerance)
         road_elevation = xyz_centre
-        assert road_elevation[:, -1].min() > -100
 
         lanes = []
         for lane in xodr_lane_section.lanes:

--- a/scenario_gym/road_network/xodr.py
+++ b/scenario_gym/road_network/xodr.py
@@ -66,9 +66,11 @@ def road_to_sg(
 
         xyz_centre = xodr_lane_section.get_offset_line()
         road_center = LineString(xyz_centre[:, :2])
+        assert xyz_centre[:, -1].min() > -100
         if simplify_tolerance is not None:
             road_center = road_center.simplify(simplify_tolerance)
         road_elevation = xyz_centre
+        assert road_elevation[:, -1].min() > -100
 
         lanes = []
         for lane in xodr_lane_section.lanes:

--- a/scenario_gym/scenario/scenario.py
+++ b/scenario_gym/scenario/scenario.py
@@ -289,7 +289,8 @@ class Scenario:
         """
         with open(path, "r") as f:
             data = json.load(f)
-        if data.get("road_network", {}).get("path") is not None:
+        rn = data.get("road_network")
+        if rn is not None and rn.get("path") is not None:
             rn_path = Path(data["road_network"]["path"])
             if not rn_path.is_absolute():
                 if road_network_dir is None:

--- a/scenario_gym/scenario_gym.py
+++ b/scenario_gym/scenario_gym.py
@@ -13,8 +13,6 @@ from scenario_gym.xosc_interface import import_scenario
 class ScenarioGym:
     """The main class that loads and runs scenarios."""
 
-    INIT_PREV_T = -0.1
-
     @classmethod
     def run_scenarios(
         cls,
@@ -220,7 +218,7 @@ class ScenarioGym:
         """Reset the state to the beginning of the current scenario."""
         self.close()
         t0 = self.get_start_time(self.state.scenario)
-        self.state.reset(t0 + self.INIT_PREV_T, t0)
+        self.state.reset(t0)
         for m in self.metrics:
             m.reset(self.state)
 

--- a/scenario_gym/state/state.py
+++ b/scenario_gym/state/state.py
@@ -103,15 +103,12 @@ class State:
         """Get the current scenario."""
         return self._scenario
 
-    def reset(self, t_minus1: float, t_0: float) -> None:
+    def reset(self, t_0: float) -> None:
         """
         Reset the state to the initial timestep.
 
         Parameters
         ----------
-        t_minus1 : float
-            Time before the initial timestep to use for initial velocities.
-
         t_0 : float
             Initial timestep.
 
@@ -121,7 +118,7 @@ class State:
 
         # set initial poses
         # always use extrapolation for previous poses to get the initial velocity
-        prev_poses, poses = {}, {}
+        velocities, poses = {}, {}
         for entity in self.all_entities:
             pose = entity.trajectory.position_at_t(
                 t_0,
@@ -132,11 +129,10 @@ class State:
             )
             if pose is not None:
                 poses[entity] = pose
-                prev_poses[entity] = entity.trajectory.position_at_t(
-                    t_minus1, extrapolate=((False, False) if self.persist else True)
-                )
-        self.update_poses(t_minus1, prev_poses)
+                velocities[entity] = entity.trajectory.velocity_at_t(t_0)
         self.update_poses(t_0, poses)
+        self.velocities.update(velocities)
+        self.prev_t = t_0 - 0.1
         self.update_actions()
 
         for cb in self.state_callbacks:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -36,6 +36,8 @@ def test_poses(scenario):
 
     assert gym.state.t == gym.state.scenario.ego.trajectory.min_t
     assert gym.state.poses
+
+    gym.step()
     assert all(
         (
             np.allclose(
@@ -44,7 +46,7 @@ def test_poses(scenario):
             for e, v in gym.state.velocities.items()
         )
     ), "Velocities not correct."
-    print(gym.state.recorded_poses())
+
     assert all(
         len(poses) == 2
         for e, poses in gym.state.recorded_poses().items()
@@ -167,14 +169,14 @@ def test_reset(scenario_path):
     state = State(scenario)
 
     n = sum(1 for e in scenario.entities if e.trajectory.min_t <= 0.0)
-    state.reset(-1.0, 0.0)
+    state.reset(0.0)
     assert len(state.poses) == n, "Wrong number of entities."
-    assert len(state.prev_poses) == n, "Wrong number of entities."
+    assert len(state.velocities) == n, "Wrong number of entities."
 
     n = sum(1 for e in scenario.entities if e.trajectory.max_t >= 100.0)
-    state.reset(-1.0, 100.0)
+    state.reset(100.0)
     assert len(state.poses) == n, "Wrong number of entities."
-    assert len(state.poses) == n, "Wrong number of entities."
+    assert len(state.velocities) == n, "Wrong number of entities."
 
 
 def test_reset_persist(scenario_path):
@@ -183,13 +185,13 @@ def test_reset_persist(scenario_path):
     state = State(scenario, persist=True)
 
     n = len(scenario.entities)
-    state.reset(-1.0, 0.0)
+    state.reset(0.0)
     assert len(state.poses) == n, "Wrong number of entities."
-    assert len(state.prev_poses) == n, "Wrong number of entities."
+    assert len(state.velocities) == n, "Wrong number of entities."
 
-    state.reset(-1.0, 100.0)
+    state.reset(100.0)
     assert len(state.poses) == n, "Wrong number of entities."
-    assert len(state.poses) == n, "Wrong number of entities."
+    assert len(state.velocities) == n, "Wrong number of entities."
 
 
 def test_state_actions(scenario):


### PR DESCRIPTION
Use the `Trajectory.velocity_at_t` method to set the initial velocities rather than assigning previous poses for a fake additional timestamp.