### PR TITLE
prevent overwriting the data attribute

### DIFF
--- a/scenario_gym/trajectory.py
+++ b/scenario_gym/trajectory.py
@@ -88,12 +88,27 @@ class Trajectory:
             setattr(self, f, d)
 
         # we will make the data readonly
-        self.data = np.array(_data).T.copy()
-        self.data.flags.writeable = False
+        self._data = np.array(_data).T.copy()
+        self._data.flags.writeable = False
 
         self._interpolated: Optional[Callable[[ArrayLike], NDArray]] = None
         self._interpolated_s: Optional[Callable[[ArrayLike], NDArray]] = None
         self._grad_fn = None
+
+    @property
+    def data(self) -> NDArray:
+        """
+        Get the underlying trajectory data.
+
+        Note this property has no setter. To modify the trajectory data one must
+        copy the data and init a new trajectory:
+        ```
+        new_data = trajectory.data.copy()
+        # apply changes
+        new_t = Trajectory(new_data)
+        ```
+        """
+        return self._data
 
     def __len__(self) -> int:
         """Return the number of points in the trajectory."""

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -340,3 +340,10 @@ def test_curvature_subsample():
     assert (subsampled.x >= 2).sum() > 0.5 * subsampled.x.shape[
         0
     ], "More points should be in the final part of the trajectory."
+
+
+def test_invalid_set():
+    """Test that we cannot explitly set the data attribute."""
+    traj = Trajectory(np.zeros((10, 3)), fields=["t", "x", "y"])
+    with pt.raises(AttributeError):
+        traj.data = np.ones((10, 3))


### PR DESCRIPTION
Makes writing to the `data` attribute of `Trajectory` raise an `AttributeError`. This is needed because otherwise many bugs can creep in from changing the `data` attribute while many cached properties of the class remain.