### PR TITLE
Fixing Failing Tests (numpy 2.0)

### DIFF
--- a/scenario_gym/xosc_interface/read.py
+++ b/scenario_gym/xosc_interface/read.py
@@ -280,9 +280,9 @@ def traj_point_from_time_and_position(t, world_position) -> np.ndarray:
             t,
             float(world_position.attrib["x"]),
             float(world_position.attrib["y"]),
-            float(world_position.attrib.get("z", np.NaN)),
-            float(world_position.attrib.get("h", np.NaN)),
-            float(world_position.attrib.get("p", np.NaN)),
-            float(world_position.attrib.get("r", np.NaN)),
+            float(world_position.attrib.get("z", np.nan)),
+            float(world_position.attrib.get("h", np.nan)),
+            float(world_position.attrib.get("p", np.nan)),
+            float(world_position.attrib.get("r", np.nan)),
         ],
     )


### PR DESCRIPTION
Usually errors in pytest appear as:
```
 AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.. Did you mean: 'nan'?
```